### PR TITLE
feat: Allow users to see their membership status and buy new ones

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -47,5 +47,13 @@
 	"proud_seemly_gull_scoop": "Membership type",
 	"quick_spare_mule_cry": "Identifier",
 	"legal_zany_tortoise_flop": "Manage individual members",
-	"fine_deft_impala_blend": "User Identifier"
+	"fine_deft_impala_blend": "User Identifier",
+	"weird_sad_gazelle_pet": "No membership",
+	"curly_equal_impala_strive": "Valid membership",
+	"good_elegant_javelina_catch": "Expired",
+	"curly_equal_panda_bake": "Awaiting payment",
+	"inclusive_bright_parrot_hike": "Awaiting approval",
+	"sea_dull_shark_slurp": "Unknown status",
+	"proof_spicy_mule_loop": "Buy membership",
+	"muddy_upper_puma_persist": "Select membership type"
 }

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -47,5 +47,13 @@
 	"proud_seemly_gull_scoop": "Jäsenyyden tyyppi",
 	"quick_spare_mule_cry": "Tunnus",
 	"legal_zany_tortoise_flop": "Hallinnoi yksittäisiä jäseniä",
-	"fine_deft_impala_blend": "Käyttäjätunnus"
+	"fine_deft_impala_blend": "Käyttäjätunnus",
+	"weird_sad_gazelle_pet": "Ei jäsenyyttä",
+	"curly_equal_impala_strive": "Voimassa oleva jäsenyys",
+	"good_elegant_javelina_catch": "Vanhentunut",
+	"curly_equal_panda_bake": "Odottaa maksua",
+	"inclusive_bright_parrot_hike": "Odottaa hyväksyntää",
+	"sea_dull_shark_slurp": "Tuntematon tila",
+	"proof_spicy_mule_loop": "Osta jäsenyys",
+	"muddy_upper_puma_persist": "Valitse jäsenyys"
 }

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ STRIPE_API_KEY=sk_test_...
 # required only on the first time
 stripe login
 
-stripe listen --forward-to localhost:"$PORT"/api/webhooks/stripe
+stripe listen --forward-to localhost:"$PORT"/api/webhook/stripe
 ```
 
 3. Set the webhook signing secret from the output of `stripe listen` to `.env`

--- a/src/lib/ROUTES.ts
+++ b/src/lib/ROUTES.ts
@@ -13,7 +13,8 @@ const PAGES = {
   "/sign-in": `/sign-in`,
   "/sign-in/email": `/sign-in/email`,
   "/admin/members": `/admin/members`,
-  "/admin/memberships": `/admin/memberships`
+  "/admin/memberships": `/admin/memberships`,
+  "/new": `/new`
 }
 
 /**
@@ -29,12 +30,12 @@ const SERVERS = {
 const ACTIONS = {
   "saveInfo /": `/?/saveInfo`,
   "signOut /": `/?/signOut`,
-  "payMembership /": `/?/payMembership`,
   "default /sign-in": `/sign-in`,
   "verify /sign-in/email": `/sign-in/email?/verify`,
   "resend /sign-in/email": `/sign-in/email?/resend`,
   "createMembership /admin/memberships": `/admin/memberships?/createMembership`,
-  "deleteMembership /admin/memberships": `/admin/memberships?/deleteMembership`
+  "deleteMembership /admin/memberships": `/admin/memberships?/deleteMembership`,
+  "payMembership /new": `/new?/payMembership`
 }
 
 /**
@@ -149,9 +150,9 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
 * ```
 */
 export type KIT_ROUTES = {
-  PAGES: { '/': never, '/sign-in': never, '/sign-in/email': never, '/admin/members': never, '/admin/memberships': never }
+  PAGES: { '/': never, '/sign-in': never, '/sign-in/email': never, '/admin/members': never, '/admin/memberships': never, '/new': never }
   SERVERS: { 'POST /api/webhook/stripe': never }
-  ACTIONS: { 'saveInfo /': never, 'signOut /': never, 'payMembership /': never, 'default /sign-in': never, 'verify /sign-in/email': never, 'resend /sign-in/email': never, 'createMembership /admin/memberships': never, 'deleteMembership /admin/memberships': never }
+  ACTIONS: { 'saveInfo /': never, 'signOut /': never, 'default /sign-in': never, 'verify /sign-in/email': never, 'resend /sign-in/email': never, 'createMembership /admin/memberships': never, 'deleteMembership /admin/memberships': never, 'payMembership /new': never }
   LINKS: Record<string, never>
   Params: Record<string, never>
 }

--- a/src/lib/server/db/seed.ts
+++ b/src/lib/server/db/seed.ts
@@ -113,6 +113,7 @@ async function main() {
 			columns: {
 				homeMunicipality: f.state(),
 				isAdmin: f.default({ defaultValue: false }),
+				stripeCustomerId: f.default({ defaultValue: null }),
 			},
 			with: {
 				member: [

--- a/src/lib/server/payment/session.ts
+++ b/src/lib/server/payment/session.ts
@@ -19,7 +19,7 @@ export async function createSession(userId: string, membershipId: string) {
 		where: eq(table.user.id, userId),
 	});
 	if (!membership || !user) {
-		return null;
+		throw new Error("Membership or user not found");
 	}
 
 	let stripeCustomerId = user.stripeCustomerId;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,12 @@
 	import { route } from "$lib/ROUTES";
 	import { Separator } from "$lib/components/ui/separator";
 	import UserCog from "@lucide/svelte/icons/user-cog";
-	import { localizeHref } from "$lib/paraglide/runtime";
+	import CircleCheck from "@lucide/svelte/icons/circle-check";
+	import CircleAlert from "@lucide/svelte/icons/circle-alert";
+	import Trash from "@lucide/svelte/icons/trash";
+	import Hourglass from "@lucide/svelte/icons/hourglass";
+	import Banknote from "@lucide/svelte/icons/banknote";
+	import { localizeHref, getLocale } from "$lib/paraglide/runtime";
 
 	let { data }: { data: PageServerData } = $props();
 
@@ -119,6 +124,55 @@
 						<p class="text-sm text-muted-foreground">{m.legal_zany_tortoise_flop()}</p>
 					</div>
 				</a>
+			</div>
+		{:else}
+			<Separator class="hidden md:block" orientation="vertical" />
+			<div class="flex w-full max-w-xs flex-col gap-4">
+				<h2 class="font-mono text-lg">{m.smug_vexed_toucan_dream()}</h2>
+				<a href={route("/new")} class="flex w-full max-w-xs flex-col">
+					<Form.Button variant="default">{m.proof_spicy_mule_loop()}</Form.Button>
+				</a>
+				{#if data.memberships.length === 0}
+					<p class="text-sm text-muted-foreground">{m.weird_sad_gazelle_pet()}</p>
+				{:else}
+					{#each data.memberships as membership (membership.unique_id)}
+						<li class="flex items-center justify-between space-x-4 rounded-md border p-4">
+							{#if membership.status === "active"}
+								<span title={m.curly_equal_impala_strive()}>
+									<CircleCheck class="h-6 w-6" />
+								</span>
+							{:else if membership.status === "expired"}
+								<span title={m.good_elegant_javelina_catch()}>
+									<Trash class="h-6 w-6" />
+								</span>
+							{:else if membership.status === "awaiting_payment"}
+								<span title={m.curly_equal_panda_bake()}>
+									<Banknote class="h-6 w-6" />
+								</span>
+							{:else if membership.status === "awaiting_approval"}
+								<span title={m.inclusive_bright_parrot_hike()}>
+									<Hourglass class="h-6 w-6" />
+								</span>
+							{:else}
+								<span title={m.sea_dull_shark_slurp()}>
+									<CircleAlert class="h-6 w-6" />
+								</span>
+							{/if}
+							<div class="flex-1 space-y-1">
+								<div class="text-sm">
+									<p class="font-medium">{membership.type}</p>
+									<p>
+										<time datetime={membership.startTime.toISOString()}
+											>{membership.startTime.toLocaleDateString(`${getLocale()}-FI`)}</time
+										>–<time datetime={membership.endTime.toISOString()}
+											>{membership.endTime.toLocaleDateString(`${getLocale()}-FI`)}</time
+										>
+									</p>
+								</div>
+							</div>
+						</li>
+					{/each}
+				{/if}
 			</div>
 		{/if}
 	</div>

--- a/src/routes/new/+page.server.ts
+++ b/src/routes/new/+page.server.ts
@@ -3,11 +3,11 @@ import type { Actions, PageServerLoad, RequestEvent } from "./$types";
 import { route } from "$lib/ROUTES";
 import { db } from "$lib/server/db";
 import * as table from "$lib/server/db/schema";
-import { eq, desc } from "drizzle-orm";
+import { eq, desc, gt } from "drizzle-orm";
 import { schema } from "./schema";
 import { superValidate } from "sveltekit-superforms";
 import { zod4 } from "sveltekit-superforms/adapters";
-import * as auth from "$lib/server/auth/session";
+import { createSession } from "$lib/server/payment/session";
 import { localizeHref } from "$lib/paraglide/runtime";
 
 export const load: PageServerLoad = async (event) => {
@@ -17,11 +17,7 @@ export const load: PageServerLoad = async (event) => {
 
 	const form = await superValidate(zod4(schema), {
 		defaults: {
-			email: event.locals.user.email,
-			firstNames: event.locals.user.firstNames ?? "",
-			lastName: event.locals.user.lastName ?? "",
-			homeMunicipality: event.locals.user.homeMunicipality ?? "",
-			isAllowedEmails: event.locals.user.isAllowedEmails,
+			membershipId: "",
 		},
 	});
 
@@ -35,18 +31,18 @@ export const load: PageServerLoad = async (event) => {
 	const memberships = result.map((m) => ({
 		...m.membership,
 		status: m.member.status,
-		unique_id: m.member.id,
 	}));
 
-	return { user: event.locals.user, form, memberships };
+	const availableMemberships = await db.select().from(table.membership).where(gt(table.membership.endTime, new Date()));
+
+	return { user: event.locals.user, form, memberships, availableMemberships };
 };
 
 export const actions: Actions = {
-	saveInfo,
-	signOut,
+	payMembership,
 };
 
-async function saveInfo(event: RequestEvent) {
+async function payMembership(event: RequestEvent) {
 	if (!event.locals.user) {
 		return fail(401, {
 			message: "Unauthorized",
@@ -56,31 +52,13 @@ async function saveInfo(event: RequestEvent) {
 	const formData = await event.request.formData();
 	const form = await superValidate(formData, zod4(schema));
 
-	const user = {
-		...event.locals.user,
-		...form.data,
-	};
-
-	await db
-		.update(table.user)
-		.set({
-			// don't allow changing email here
-			firstNames: user.firstNames,
-			lastName: user.lastName,
-			homeMunicipality: user.homeMunicipality,
-			isAllowedEmails: user.isAllowedEmails,
-		})
-		.where(eq(table.user.id, user.id));
-
-	return redirect(302, localizeHref(route("/")));
-}
-
-async function signOut(event: RequestEvent) {
-	if (!event.locals.session) {
-		return fail(401);
+	const membershipId = form.data.membershipId;
+	const paymentSession = await createSession(event.locals.user.id, membershipId);
+	if (!paymentSession?.url) {
+		return fail(400, {
+			form,
+			message: "Could not create payment session",
+		});
 	}
-	await auth.invalidateSession(event.locals.session.id);
-	auth.deleteSessionTokenCookie(event);
-
-	return redirect(302, localizeHref(route("/sign-in")));
+	return redirect(303, paymentSession.url);
 }

--- a/src/routes/new/+page.svelte
+++ b/src/routes/new/+page.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import type { PageProps } from "./$types";
+	import * as m from "$lib/paraglide/messages.js";
+	import { zod4Client } from "sveltekit-superforms/adapters";
+	import { superForm } from "sveltekit-superforms";
+	import { schema } from "./schema";
+	import { route } from "$lib/ROUTES";
+	import * as Form from "$lib/components/ui/form/index.js";
+	import { getLocale } from "$lib/paraglide/runtime";
+
+	const { data }: PageProps = $props();
+
+	const form = superForm(data.form, {
+		validators: zod4Client(schema),
+	});
+	const { form: formData, enhance } = form;
+
+	const { memberships, availableMemberships } = data;
+	const filteredMemberships = availableMemberships.filter((a) => !memberships.some((b) => a.id === b.id));
+</script>
+
+<main class="my-4 flex flex-col items-center justify-center">
+	<h1 class="font-mono text-lg">{m.proof_spicy_mule_loop()}</h1>
+	<form method="post" action={route("payMembership /new")} use:enhance class="flex w-full max-w-xs flex-col gap-4">
+		<Form.Field {form} name="membershipId" class="space-y flex flex-col gap-1 rounded-lg border p-4">
+			<Form.Control>
+				<Form.Label>{m.muddy_upper_puma_persist()}</Form.Label>
+				<select class="bg-background" name="membershipId" bind:value={$formData.membershipId} required>
+					{#each filteredMemberships as membership (membership.id)}
+						<option value={membership.id}>
+							{membership.type} - {new Date(membership.startTime).toLocaleDateString(`${getLocale()}-FI`)} – {new Date(
+								membership.endTime,
+							).toLocaleDateString(`${getLocale()}-FI`)} ({membership.priceCents / 100} €)
+						</option>
+					{/each}
+				</select>
+			</Form.Control>
+		</Form.Field>
+		<Form.Button type="submit">
+			{m.proof_spicy_mule_loop()}
+			{#if $formData.membershipId}
+				({(availableMemberships.find((x) => x.id === $formData.membershipId)?.priceCents ?? 0) / 100} €)
+			{/if}
+		</Form.Button>
+	</form>
+</main>

--- a/src/routes/new/schema.ts
+++ b/src/routes/new/schema.ts
@@ -1,0 +1,5 @@
+import * as z from "zod/v4";
+
+export const schema = z.object({
+	membershipId: z.string(),
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,10 @@ const localizedPaths = {
 		fi: "/kirjaudu-sisaan/sahkoposti",
 		en: "/sign-in/email",
 	},
+	"/new": {
+		fi: "/uusi",
+		en: "/new",
+	},
 	"/admin/memberships": {
 		fi: "/hallinta/jasenyydet",
 		en: "/admin/memberships",


### PR DESCRIPTION
Users can now see their memberships in the index page (with symbol and alt text describing the status). Users can purchase new memberships. Currently allows anyone to buy any membership, checking student status can be added later.

List memberships in the index page:
![image](https://github.com/user-attachments/assets/d6175af8-bff8-4836-99c6-bbb41abafc3b)

Buying membership:
![image](https://github.com/user-attachments/assets/745a231c-071f-48d7-9574-1fdd5f9576ed)

Maybe closes #11 ?
