### PR TITLE
feat: Playwright E2E authentication infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DATABASE_URL="postgres://root:mysecretpassword@localhost:5432/local"
+DATABASE_URL_TEST="postgres://root:mysecretpassword@localhost:5432/local_test"
 
 STRIPE_API_KEY="sk_test_..."
 STRIPE_WEBHOOK_SECRET="whsec_..."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
 
     env:
       DATABASE_URL: postgres://root:mysecretpassword@localhost:5432/local
+      DATABASE_URL_TEST: postgres://root:mysecretpassword@localhost:5432/local_test
       STRIPE_API_KEY: sk_test_...
       STRIPE_WEBHOOK_SECRET: whsec_...
 
@@ -52,6 +53,9 @@ jobs:
 
       - name: Install browsers
         run: pnpm exec playwright install
+
+      - name: Copy .env example
+        run: cp .env.example .env
 
       - name: Push db schema
         run: pnpm db:push:force

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 test-results
 node_modules
 
+# Playwright
+e2e/.auth/
+
 # Output
 .output
 .vercel

--- a/e2e/auth.test.ts
+++ b/e2e/auth.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "./fixtures/auth";
+
+test.describe("Authentication", () => {
+	test("admin page fixture can access admin members page", async ({ adminPage }) => {
+		// Navigate to admin members page which requires authentication
+		await adminPage.goto("/admin/members", { waitUntil: "networkidle" });
+
+		// Verify we're on the admin members page (handles i18n routes)
+		// and not redirected to sign-in page
+		await expect(adminPage).toHaveURL(/\/(hallinta\/jasenet|admin\/members)/);
+		await expect(adminPage).not.toHaveURL(/sign-in|kirjaudu/);
+	});
+
+	test("authenticated admin can see user profile on home page", async ({ adminPage }) => {
+		await adminPage.goto("/", { waitUntil: "networkidle" });
+
+		// Verify we're not redirected to sign-in
+		await expect(adminPage).not.toHaveURL(/sign-in|kirjaudu/);
+
+		// Check for readonly email input (indicates authenticated user viewing their profile)
+		const emailInput = adminPage.locator('input[type="email"]').first();
+		await expect(emailInput).toBeVisible();
+		await expect(emailInput).toHaveValue("root@tietokilta.fi");
+	});
+});

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,46 @@
+import { test as base, type Page } from "@playwright/test";
+import path from "node:path";
+
+type AuthFixtures = {
+	authenticatedPage: Page;
+	adminPage: Page;
+};
+
+/**
+ * Extended test fixture with authenticated page contexts using storage state
+ */
+export const test = base.extend<AuthFixtures>({
+	/**
+	 * Creates an authenticated page with a regular user session
+	 * Uses the admin storage state for now
+	 */
+	authenticatedPage: async ({ browser }, use) => {
+		const storageStatePath = path.join(process.cwd(), "e2e/.auth/admin.json");
+		const context = await browser.newContext({
+			storageState: storageStatePath,
+		});
+		const page = await context.newPage();
+
+		await use(page);
+
+		await context.close();
+	},
+
+	/**
+	 * Creates an authenticated page with an admin user session
+	 * Uses the pre-created admin storage state from global setup
+	 */
+	adminPage: async ({ browser }, use) => {
+		const storageStatePath = path.join(process.cwd(), "e2e/.auth/admin.json");
+		const context = await browser.newContext({
+			storageState: storageStatePath,
+		});
+		const page = await context.newPage();
+
+		await use(page);
+
+		await context.close();
+	},
+});
+
+export { expect } from "@playwright/test";

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,93 @@
+import { chromium, type FullConfig } from "@playwright/test";
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import * as table from "../src/lib/server/db/schema";
+import { sha256 } from "@oslojs/crypto/sha2";
+import { encodeBase64url, encodeHexLowerCase } from "@oslojs/encoding";
+import { eq } from "drizzle-orm";
+import { execSync } from "node:child_process";
+import { loadEnvFile } from "./utils";
+
+async function globalSetup(_config: FullConfig) {
+	loadEnvFile();
+
+	const dbUrl = process.env.DATABASE_URL_TEST;
+	if (!dbUrl) {
+		throw new Error("DATABASE_URL_TEST not set. Make sure .env file exists with DATABASE_URL_TEST.");
+	}
+
+	const url = new URL(dbUrl);
+	const testDbName = url.pathname.substring(1);
+
+	const baseDbUrl = new URL(dbUrl);
+	baseDbUrl.pathname = "/postgres";
+	const adminClient = postgres(baseDbUrl.toString());
+
+	try {
+		const result = await adminClient`SELECT 1 FROM pg_database WHERE datname = ${testDbName}`;
+		if (result.length === 0) {
+			await adminClient.unsafe(`CREATE DATABASE ${testDbName}`);
+			console.log(`✓ Created test database: ${testDbName}`);
+		}
+	} finally {
+		await adminClient.end();
+	}
+
+	const client = postgres(dbUrl);
+	const db = drizzle(client, { schema: table, casing: "snake_case" });
+
+	console.log("✓ Pushing schema to test database...");
+	execSync(`DATABASE_URL="${dbUrl}" pnpm drizzle-kit push --force`, { stdio: "inherit" });
+
+	let [adminUser] = await db.select().from(table.user).where(eq(table.user.email, "root@tietokilta.fi")).limit(1);
+
+	if (!adminUser) {
+		console.log("✓ Seeding test database...");
+		execSync(`DATABASE_URL="${dbUrl}" pnpm tsx --env-file=.env src/lib/server/db/seed.ts`, {
+			stdio: "inherit",
+		});
+		[adminUser] = await db.select().from(table.user).where(eq(table.user.email, "root@tietokilta.fi")).limit(1);
+		if (!adminUser) {
+			throw new Error("Failed to seed admin user");
+		}
+	}
+
+	const sessionToken = generateSessionToken();
+	const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(sessionToken)));
+	const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
+
+	await db.insert(table.session).values({
+		id: sessionId,
+		userId: adminUser.id,
+		expiresAt,
+	});
+
+	const browser = await chromium.launch();
+	const context = await browser.newContext();
+
+	await context.addCookies([
+		{
+			name: "auth-session",
+			value: sessionToken,
+			domain: "localhost",
+			path: "/",
+			expires: Math.floor(expiresAt.getTime() / 1000),
+			httpOnly: false,
+			secure: false,
+			sameSite: "Lax",
+		},
+	]);
+
+	await context.storageState({ path: "e2e/.auth/admin.json" });
+	await browser.close();
+	await client.end();
+
+	console.log("✓ Created authenticated admin session for tests");
+}
+
+function generateSessionToken() {
+	const bytes = crypto.getRandomValues(new Uint8Array(18));
+	return encodeBase64url(bytes);
+}
+
+export default globalSetup;

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+
+export function loadEnvFile() {
+	try {
+		const envFile = readFileSync(".env", "utf-8");
+		envFile.split("\n").forEach((line) => {
+			const trimmed = line.trim();
+			if (trimmed && !trimmed.startsWith("#")) {
+				const [key, ...valueParts] = trimmed.split("=");
+				const value = valueParts.join("=").replace(/^["']|["']$/g, "");
+				if (key && value) {
+					process.env[key.trim()] = value.trim();
+				}
+			}
+		});
+	} catch (e) {
+		console.warn("Could not load .env file:", e);
+	}
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,25 @@
 import { defineConfig } from "@playwright/test";
+import { loadEnvFile } from "./e2e/utils";
+
+loadEnvFile();
+const testDbUrl = process.env.DATABASE_URL_TEST;
 
 export default defineConfig({
 	webServer: {
-		command: "npm run build && npm run preview",
+		command: "pnpm build && pnpm preview",
 		port: 4173,
+		env: {
+			DATABASE_URL: testDbUrl || "",
+		},
 	},
 
 	testDir: "e2e",
+
+	globalSetup: "./e2e/global-setup.ts",
+
+	use: {
+		baseURL: "http://localhost:4173",
+		locale: "fi-FI",
+		timezoneId: "Europe/Helsinki",
+	},
 });


### PR DESCRIPTION
## Summary
- Sets up reusable authentication infrastructure for E2E tests
- Global setup automatically creates authenticated admin session
- Auto-creates and manages test database (from `DATABASE_URL_TEST`)
- Auth fixtures provide `adminPage` and `authenticatedPage`
- Tests run in Finnish locale with proper timezone

## Setup Required
Add to `.env`:
```
DATABASE_URL_TEST="postgres://root:mysecretpassword@localhost:5432/local_test"
```

## Test Plan
- [x] All tests pass with `pnpm test`
- [x] Auth fixtures work for admin pages
- [x] Test database is isolated from dev database
- [x] No manual setup required after adding env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)