### PR TITLE
fix: expose port 3000 in Docker image for Azure deployment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,9 +82,14 @@
           docker = pkgs.dockerTools.buildLayeredImage {
             name = "rekisteri";
             tag = "latest";
-            config.Cmd = [
-              "${default}/bin/rekisteri"
-            ];
+            config = {
+              Cmd = [
+                "${default}/bin/rekisteri"
+              ];
+              ExposedPorts = {
+                "3000/tcp" = {};
+              };
+            };
           };
         }
       );


### PR DESCRIPTION
Azure App Service requires Docker images to expose a port. Without EXPOSE, Azure defaults to port 80 but doesn't know which port the app listens on.

The app will still respect the PORT environment variable (which Azure sets), but EXPOSE tells Azure where to route traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)