### PR TITLE
fix: use SSL prefer mode for PostgreSQL connections

### DIFF
--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -1,7 +1,10 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { env } from "$env/dynamic/private";
+import { dev } from "$app/environment";
 import * as schema from "$lib/server/db/schema";
 if (!env.DATABASE_URL) throw new Error("DATABASE_URL is not set");
-const client = postgres(env.DATABASE_URL);
+const client = postgres(env.DATABASE_URL, {
+	ssl: dev ? undefined : "prefer", // Prefer SSL in production, optional in dev
+});
 export const db = drizzle(client, { schema, casing: "snake_case" });

--- a/src/start-with-migrations.ts
+++ b/src/start-with-migrations.ts
@@ -19,7 +19,10 @@ const __dirname = dirname(__filename);
 async function runMigrations(databaseUrl: string) {
 	console.log("Starting database migrations...");
 
-	const migrationClient = postgres(databaseUrl, { max: 1 });
+	const migrationClient = postgres(databaseUrl, {
+		max: 1,
+		ssl: "prefer", // Prefer SSL (required for Azure), but allow non-SSL for CI/local
+	});
 	const db = drizzle(migrationClient, { casing: "snake_case" });
 
 	// The drizzle folder is at the same level as this script


### PR DESCRIPTION
Configure postgres clients to prefer SSL but allow fallback to non-SSL:
- Migration script: ssl: 'prefer'
- Main db client: ssl: 'prefer' in prod, undefined in dev
- Seed script: unchanged (dev only, local postgres)

This allows:
- Azure PostgreSQL: Uses SSL (as required)
- CI/local postgres: Falls back to non-SSL when SSL unavailable

Fixes Azure deployment error: "no pg_hba.conf entry..., no encryption"
Fixes CI health check: "Client network socket disconnected before secure TLS connection"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>