### PR TITLE
fix: add CA certificates to Docker image for HTTPS requests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,9 @@
           docker = pkgs.dockerTools.buildLayeredImage {
             name = "rekisteri";
             tag = "latest";
+            contents = [
+              pkgs.cacert # Add CA certificates for HTTPS requests
+            ];
             config = {
               Cmd = [
                 "${default}/bin/rekisteri"
@@ -89,6 +92,9 @@
               ExposedPorts = {
                 "3000/tcp" = {};
               };
+              Env = [
+                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+              ];
             };
           };
         }


### PR DESCRIPTION
The minimal Nix Docker image was missing CA certificates, causing TLS verification errors when connecting to external APIs like Mailgun.

Adds:
- pkgs.cacert to image contents
- SSL_CERT_FILE environment variable pointing to CA bundle

Fixes: UNABLE_TO_GET_ISSUER_CERT_LOCALLY error when sending emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)