### PR TITLE
fix: allow changing email address during login flow

### DIFF
--- a/src/lib/ROUTES.ts
+++ b/src/lib/ROUTES.ts
@@ -22,6 +22,7 @@ const PAGES = {
  * SERVERS
  */
 const SERVERS = {
+  "GET /api/health": `/api/health`,
   "POST /api/webhook/stripe": `/api/webhook/stripe`
 }
 
@@ -34,6 +35,7 @@ const ACTIONS = {
   "default /sign-in": `/sign-in`,
   "verify /sign-in/email": `/sign-in/email?/verify`,
   "resend /sign-in/email": `/sign-in/email?/resend`,
+  "changeEmail /sign-in/email": `/sign-in/email?/changeEmail`,
   "approve /admin/members": `/admin/members?/approve`,
   "reject /admin/members": `/admin/members?/reject`,
   "markExpired /admin/members": `/admin/members?/markExpired`,
@@ -158,8 +160,8 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
 */
 export type KIT_ROUTES = {
   PAGES: { '/': never, '/sign-in': never, '/sign-in/email': never, '/admin/members': never, '/admin/members/import': never, '/admin/memberships': never, '/new': never }
-  SERVERS: { 'POST /api/webhook/stripe': never }
-  ACTIONS: { 'saveInfo /': never, 'signOut /': never, 'default /sign-in': never, 'verify /sign-in/email': never, 'resend /sign-in/email': never, 'approve /admin/members': never, 'reject /admin/members': never, 'markExpired /admin/members': never, 'cancel /admin/members': never, 'reactivate /admin/members': never, 'import /admin/members/import': never, 'createMembership /admin/memberships': never, 'deleteMembership /admin/memberships': never, 'payMembership /new': never }
+  SERVERS: { 'GET /api/health': never, 'POST /api/webhook/stripe': never }
+  ACTIONS: { 'saveInfo /': never, 'signOut /': never, 'default /sign-in': never, 'verify /sign-in/email': never, 'resend /sign-in/email': never, 'changeEmail /sign-in/email': never, 'approve /admin/members': never, 'reject /admin/members': never, 'markExpired /admin/members': never, 'cancel /admin/members': never, 'reactivate /admin/members': never, 'import /admin/members/import': never, 'createMembership /admin/memberships': never, 'deleteMembership /admin/memberships': never, 'payMembership /new': never }
   LINKS: Record<string, never>
   Params: Record<string, never>
 }

--- a/src/lib/i18n/en/index.ts
+++ b/src/lib/i18n/en/index.ts
@@ -15,6 +15,7 @@ const en = {
 		verify: "Verify",
 		codeSentTo: "We sent an 8-digit code to {email}.",
 		resendCode: "Resend code",
+		changeEmail: "Change email address",
 		emailSubject: "CSG Membership Registry Sign In Code",
 		emailBody: "Your code is {code}",
 	},

--- a/src/lib/i18n/fi/index.ts
+++ b/src/lib/i18n/fi/index.ts
@@ -15,6 +15,7 @@ const fi = {
 		verify: "Vahvista",
 		codeSentTo: "Lähetimme 8-numeroisen koodin osoitteeseen {email}.",
 		resendCode: "Lähetä uusi koodi",
+		changeEmail: "Vaihda sähköpostiosoite",
 		emailSubject: "Tietokillan jäsenrekisterin sisäänkirjautumiskoodi",
 		emailBody: "Koodisi on {code}",
 	},

--- a/src/routes/(auth)/sign-in/+page.server.ts
+++ b/src/routes/(auth)/sign-in/+page.server.ts
@@ -2,7 +2,7 @@ import { fail, redirect } from "@sveltejs/kit";
 import type { Actions, PageServerLoad, RequestEvent } from "./$types";
 import { RefillingTokenBucket } from "$lib/server/auth/rate-limit";
 import * as z from "zod/v4";
-import { setEmailCookie } from "$lib/server/auth/email";
+import { setEmailCookie, emailCookieName } from "$lib/server/auth/email";
 import { route } from "$lib/ROUTES";
 import { localizePathname, getLocaleFromPathname } from "$lib/i18n/routing";
 
@@ -13,6 +13,14 @@ export const load: PageServerLoad = async (event) => {
 		const locale = getLocaleFromPathname(event.url.pathname);
 		redirect(302, localizePathname(route("/"), locale));
 	}
+
+	// If email cookie exists, redirect to OTP verification page
+	const emailCookie = event.cookies.get(emailCookieName);
+	if (emailCookie) {
+		const locale = getLocaleFromPathname(event.url.pathname);
+		redirect(302, localizePathname(route("/sign-in/email"), locale));
+	}
+
 	return {};
 };
 

--- a/src/routes/(auth)/sign-in/email/+page.server.ts
+++ b/src/routes/(auth)/sign-in/email/+page.server.ts
@@ -44,6 +44,7 @@ const otpVerifyBucket = new ExpiringTokenBucket<string>(5, 60 * 30);
 export const actions: Actions = {
 	verify: verifyCode,
 	resend: resendEmail,
+	changeEmail: changeEmail,
 };
 
 async function verifyCode(event: RequestEvent) {
@@ -172,4 +173,20 @@ async function resendEmail(event: RequestEvent) {
 			message: "A new code was sent to your inbox.",
 		},
 	};
+}
+
+async function changeEmail(event: RequestEvent) {
+	// Get the OTP to delete it if it exists
+	const otp = await getEmailOTPFromRequest(event);
+	if (otp !== null) {
+		deleteEmailOTP(otp.id);
+	}
+
+	// Clear cookies
+	deleteEmailCookie(event);
+	deleteEmailOTPCookie(event);
+
+	// Redirect back to sign-in page
+	const locale = getLocaleFromPathname(event.url.pathname);
+	redirect(303, localizePathname(route("/sign-in"), locale));
 }

--- a/src/routes/(auth)/sign-in/email/+page.svelte
+++ b/src/routes/(auth)/sign-in/email/+page.svelte
@@ -47,5 +47,8 @@
 				<p>{form.resend.message}</p>
 			{/if}
 		</form>
+		<form method="post" use:enhance action="?/changeEmail" class="contents">
+			<Button type="submit" variant="outline">{$LL.auth.changeEmail()}</Button>
+		</form>
 	</div>
 </main>


### PR DESCRIPTION
Previously, once a user entered an email, it was stored in a cookie and couldn't be changed without manually clearing cookies. This caused confusion when users wanted to try a different email address.

Changes:
- Add "Change email address" button to OTP verification page
- Redirect to OTP page if email cookie exists when visiting sign-in page
- Add server action to clear email cookies and redirect back to sign-in
- Add translations for "changeEmail" in Finnish and English

🤖 Generated with [Claude Code](https://claude.com/claude-code)