### PR TITLE
feat: add custom 404 and error pages

### DIFF
--- a/src/lib/i18n/en/index.ts
+++ b/src/lib/i18n/en/index.ts
@@ -269,6 +269,18 @@ const en = {
 		delete: "Delete",
 	},
 
+	// Error page
+	error: {
+		title: "Oops! Something went wrong",
+		notFound: "Page not found",
+		notFoundDescription: "The page you're looking for doesn't exist or has been moved.",
+		serverError: "Server error",
+		genericError: "An error occurred",
+		errorCode: "Error code: {code}",
+		backToHome: "Back to home",
+		tryAgain: "Try again",
+	},
+
 	// Documents & Legal
 	documents: {
 		memberRegistryPrivacy: {

--- a/src/lib/i18n/fi/index.ts
+++ b/src/lib/i18n/fi/index.ts
@@ -269,6 +269,18 @@ const fi = {
 		delete: "Poista",
 	},
 
+	// Error page
+	error: {
+		title: "Hups! Jotain meni pieleen",
+		notFound: "Sivua ei löytynyt",
+		notFoundDescription: "Etsimääsi sivua ei ole olemassa tai se on siirretty.",
+		serverError: "Palvelinvirhe",
+		genericError: "Tapahtui virhe",
+		errorCode: "Virhekoodi: {code}",
+		backToHome: "Palaa etusivulle",
+		tryAgain: "Yritä uudelleen",
+	},
+
 	// Documents & Legal
 	documents: {
 		memberRegistryPrivacy: {

--- a/src/routes/[locale=locale]/+error.svelte
+++ b/src/routes/[locale=locale]/+error.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { page } from "$app/state";
+	import { LL, locale } from "$lib/i18n/i18n-svelte";
+	import { route } from "$lib/ROUTES";
+	import * as Card from "$lib/components/ui/card/index.js";
+	import { Button } from "$lib/components/ui/button/index.js";
+
+	const is404 = $derived(page.status === 404);
+	const is5xx = $derived(page.status >= 500 && page.status < 600);
+</script>
+
+<div class="container mx-auto flex min-h-[calc(100vh-14rem)] max-w-2xl items-center justify-center px-4 py-12">
+	<Card.Root class="w-full">
+		<Card.Header class="text-center">
+			<div class="mb-4 text-6xl font-bold text-muted-foreground">
+				{page.status}
+			</div>
+			<Card.Title class="text-2xl">
+				{#if is404}
+					{$LL.error.notFound()}
+				{:else if is5xx}
+					{$LL.error.serverError()}
+				{:else}
+					{$LL.error.genericError()}
+				{/if}
+			</Card.Title>
+			<Card.Description class="mt-2 text-base">
+				{#if is404}
+					{$LL.error.notFoundDescription()}
+				{:else if page.error?.message}
+					{page.error.message}
+				{:else}
+					{$LL.error.title()}
+				{/if}
+			</Card.Description>
+		</Card.Header>
+		<Card.Content class="flex flex-col items-center gap-4">
+			<div class="flex flex-col gap-2 sm:flex-row">
+				<Button href={route("/[locale=locale]", { locale: $locale })} variant="default">
+					{$LL.error.backToHome()}
+				</Button>
+				{#if !is404}
+					<Button onclick={() => globalThis.location.reload()} variant="outline">
+						{$LL.error.tryAgain()}
+					</Button>
+				{/if}
+			</div>
+			{#if import.meta.env.DEV && page.error?.message}
+				<details class="mt-4 w-full">
+					<summary class="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
+						{$LL.error.errorCode({ code: String(page.status) })}
+					</summary>
+					<pre class="mt-2 overflow-auto rounded-lg bg-muted p-4 text-xs">{JSON.stringify(page.error, null, 2)}</pre>
+				</details>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+</div>


### PR DESCRIPTION
Add a nice 404/error page following SvelteKit best practices:
- Created +error.svelte in the locale route for proper i18n support
- Added error translations for both Finnish and English
- Displays different messages for 404, 5xx, and generic errors
- Styled with existing UI components (Card, Button)
- Shows error details in development mode
- Provides "Back to home" and "Try again" actions