### PR TITLE
fix: user info form not refreshing on save

### DIFF
--- a/src/routes/[locale=locale]/+page.svelte
+++ b/src/routes/[locale=locale]/+page.svelte
@@ -21,6 +21,7 @@
 	import KeyRound from "@lucide/svelte/icons/key-round";
 	import Mail from "@lucide/svelte/icons/mail";
 	import PasskeyRegistrationBanner from "$lib/components/PasskeyRegistrationBanner.svelte";
+	import { invalidateAll } from "$app/navigation";
 
 	let { data }: { data: PageServerData } = $props();
 
@@ -32,9 +33,10 @@
 	const form = superForm(data.form, {
 		validators: zod4Client(schema),
 		validationMethod: "oninput",
-		onResult({ result }) {
+		async onResult({ result }) {
 			if (result.type === "success" && result.data?.success) {
 				toast.success($LL.user.saveSuccess());
+				await invalidateAll();
 			} else if (result.type === "failure") {
 				toast.error($LL.user.saveError());
 			}


### PR DESCRIPTION
Previously, when users saved their information on the main page, the form would update but the displayed data (like the welcome message) wouldn't refresh until a full page reload. This made the UI feel buggy.

This fix adds invalidateAll() to the form's onResult callback, which tells SvelteKit to rerun all load functions and refresh the page data after a successful save. Now the UI updates immediately to reflect the changes.

Changes:
- Import invalidateAll from $app/navigation
- Make onResult async and call invalidateAll() on success
- This refreshes data.user which is displayed in the welcome message