### PR TITLE
fix: skip email sending in test environment

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
 		env: {
 			DATABASE_URL: testDbUrl,
 			UNSAFE_DISABLE_RATE_LIMITS: "true",
+			TEST: "true",
 		},
 	},
 

--- a/src/lib/server/auth/email.ts
+++ b/src/lib/server/auth/email.ts
@@ -8,6 +8,7 @@ import { dev } from "$app/environment";
 import { sendEmail } from "$lib/server/mailgun";
 import { i18nObject } from "$lib/i18n/i18n-util";
 import { loadLocale } from "$lib/i18n/i18n-util.sync";
+import { env } from "$lib/server/env";
 
 import type { EmailOTP } from "$lib/server/db/schema";
 import type { RequestEvent } from "@sveltejs/kit";
@@ -76,8 +77,9 @@ export function sendOTPEmail(email: string, code: string, locale: "fi" | "en" = 
 		text: LL.auth.emailBody({ code }),
 	};
 
-	if (dev) {
-		console.log("[Email] OTP email (dev mode):", emailOptions);
+	if (dev || env.TEST) {
+		const mode = dev ? "dev" : "test";
+		console.log(`[Email] OTP email (${mode} mode):`, emailOptions);
 	} else {
 		sendEmail(emailOptions).catch((err) => {
 			// Critical: OTP emails are essential for authentication


### PR DESCRIPTION
Add a TEST environment variable to disable actual email sending during tests, similar to how dev mode works. This prevents "Failed to send OTP email" errors during Playwright tests while keeping NODE_ENV=production for accurate test environment behavior.

Also refactored the booleanish env var parsing into a reusable helper.