### PR TITLE
feat: optimize CSV import with batch inserts and add comprehensive tests

### DIFF
--- a/e2e/csv-import.test.ts
+++ b/e2e/csv-import.test.ts
@@ -427,11 +427,15 @@ Charlie,Brown,Espoo,${email3},varsinainen jäsen,2025-08-01`;
 		await adminPage.goto(route("/[locale=locale]/admin/members/import", { locale: "fi" }), {
 			waitUntil: "networkidle",
 		});
-		await fileInput.setInputFiles(tempPath);
+
+		// Re-query elements after navigation to avoid stale references
+		const fileInput2 = adminPage.locator('input[type="file"]');
+		await fileInput2.setInputFiles(tempPath);
 
 		await expect(adminPage.getByText("Tuonnin esikatselu")).toBeVisible({ timeout: 10_000 });
 
-		await importButton.click();
+		const importButton2 = adminPage.getByRole("button", { name: /tuo.*jäsen|import.*member/i });
+		await importButton2.click();
 
 		await expect(adminPage.getByText(/tuonti onnistui|import successful/i)).toBeVisible({ timeout: 10_000 });
 


### PR DESCRIPTION
- Refactored CSV import to use batch inserts (500 rows per batch) instead of individual inserts
- Added batching for user creation, user updates, and member record creation
- Improved performance for large imports by reducing database round-trips
- Added test for 2000 row imports to verify batch handling
- Added idempotency test to ensure running same import twice doesn't create duplicates
- Fixed PostgreSQL parameter limit concerns by chunking operations
- Deduplicates users and members by email/membership to prevent duplicates in CSV data

Technical details:
- New users are batch inserted in chunks of 500
- Existing users are updated individually (Drizzle limitation)
- Member records are batch inserted after checking for existing records
- Uses inArray for efficient batch querying of existing members
- Handles errors gracefully with per-row error tracking