### PR TITLE
fix: button enabled without email verification

### DIFF
--- a/src/routes/[locale=locale]/(app)/new/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/new/+page.svelte
@@ -26,7 +26,7 @@
 		availableMemberships.find((e) => e.id === payMembership.fields.membershipId.value())?.requiresStudentVerification ??
 			false,
 	);
-	let disableForm = $derived(!isStudent && requireStudentVerification);
+	let disableForm = $derived(requireStudentVerification && (!isStudent || !data.hasValidAaltoEmail));
 </script>
 
 <div class="container mx-auto max-w-2xl px-4 py-8">


### PR DESCRIPTION
The button was enabled once the user checked "I am a student" even if they didn't have a verified aalto.fi email. Now the button is disabled when student verification is required AND either the checkbox is not checked OR there is no valid Aalto email.