### PR TITLE
Add post-verification redirect support for email verification flow

### DIFF
--- a/src/lib/api/secondary-emails.schema.ts
+++ b/src/lib/api/secondary-emails.schema.ts
@@ -2,4 +2,6 @@ import * as v from "valibot";
 
 export const addSecondaryEmailSchema = v.object({
 	email: v.pipe(v.string(), v.email()),
+	// Optional redirect URL for returning to the original page after verification
+	redirect: v.optional(v.pipe(v.string(), v.minLength(1))),
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -47,3 +47,36 @@ export function formatShortDateRange(start: Date, end: Date, locale: string): st
 	const endStr = end.toLocaleDateString(`${locale}-FI`, { day: "numeric", month: "numeric", year: "numeric" });
 	return `${startStr} – ${endStr}`;
 }
+
+/**
+ * Validate a redirect URL to ensure it's a safe pathname-only redirect within the same origin.
+ * Returns the validated pathname (with optional query string) or null if invalid.
+ *
+ * Security: Only allows pathname-only redirects to prevent open redirect vulnerabilities.
+ * - Must start with a single forward slash
+ * - Cannot start with // (protocol-relative URL)
+ * - Cannot contain protocol (http:, https:, etc.)
+ * - Cannot contain backslashes (can be used to bypass checks in some browsers)
+ */
+export function validateRedirectUrl(url: string | null | undefined): string | null {
+	if (!url || typeof url !== "string") {
+		return null;
+	}
+
+	// Must start with exactly one forward slash (pathname)
+	if (!url.startsWith("/") || url.startsWith("//")) {
+		return null;
+	}
+
+	// Block backslashes (can be interpreted as forward slashes in some browsers)
+	if (url.includes("\\")) {
+		return null;
+	}
+
+	// Block protocol handlers
+	if (url.includes(":")) {
+		return null;
+	}
+
+	return url;
+}

--- a/src/routes/[locale=locale]/(app)/new/+page.server.ts
+++ b/src/routes/[locale=locale]/(app)/new/+page.server.ts
@@ -59,6 +59,9 @@ export const load: PageServerLoad = async (event) => {
 	const hasValidAaltoEmail = isPrimaryAalto || hasValidSecondaryAalto;
 	const hasExpiredAaltoEmail = !isPrimaryAalto && hasExpiredSecondaryAalto;
 
+	// Read membershipId from query params for form state restoration (e.g., after email verification redirect)
+	const membershipIdParam = event.url.searchParams.get("membershipId");
+
 	return {
 		user: event.locals.user,
 		memberships,
@@ -66,5 +69,7 @@ export const load: PageServerLoad = async (event) => {
 		hasValidAaltoEmail,
 		hasExpiredAaltoEmail,
 		aaltoEmailExpiry: isPrimaryAalto ? null : aaltoSecondaryEmail?.expiresAt,
+		// Pass membershipId for form pre-selection after redirect
+		initialMembershipId: membershipIdParam,
 	};
 };

--- a/src/routes/[locale=locale]/(app)/settings/emails/+page.server.ts
+++ b/src/routes/[locale=locale]/(app)/settings/emails/+page.server.ts
@@ -1,16 +1,22 @@
 import { error } from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
 import { getUserSecondaryEmails } from "$lib/server/auth/secondary-email";
+import { validateRedirectUrl } from "$lib/utils";
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, url }) => {
 	if (!locals.user) {
 		return error(401, "Not authenticated");
 	}
 
 	const emails = await getUserSecondaryEmails(locals.user.id);
 
+	// Read and validate the redirect URL from query params
+	const redirectParam = url.searchParams.get("redirect");
+	const validatedRedirect = validateRedirectUrl(redirectParam);
+
 	return {
 		emails,
 		primaryEmail: locals.user.email,
+		redirect: validatedRedirect,
 	};
 };

--- a/src/routes/[locale=locale]/(app)/settings/emails/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/settings/emails/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { invalidateAll } from "$app/navigation";
 	import { LL, locale } from "$lib/i18n/i18n-svelte";
-	import { route } from "$lib/ROUTES";
+	import { route, appendSp } from "$lib/ROUTES";
 	import { Button } from "$lib/components/ui/button/index.js";
 	import * as Item from "$lib/components/ui/item/index.js";
 	import * as Card from "$lib/components/ui/card/index.js";
@@ -35,6 +35,15 @@
 		if (!date) return "";
 		return new Date(date).toLocaleDateString();
 	}
+
+	// Build add email URL with redirect param if present
+	const addEmailHref = $derived(() => {
+		const baseUrl = route("/[locale=locale]/settings/emails/add", { locale: $locale });
+		if (data.redirect) {
+			return baseUrl + appendSp({ redirect: data.redirect });
+		}
+		return baseUrl;
+	});
 </script>
 
 <Card.Root>
@@ -42,10 +51,7 @@
 		<Card.Title>{$LL.settings.emails.title()}</Card.Title>
 		<Card.Description>{$LL.secondaryEmail.manageDescription()}</Card.Description>
 		<Card.Action>
-			<Button
-				href={route("/[locale=locale]/settings/emails/add", { locale: $locale })}
-				data-testid="add-secondary-email"
-			>
+			<Button href={addEmailHref()} data-testid="add-secondary-email">
 				+ {$LL.secondaryEmail.addEmail()}
 			</Button>
 		</Card.Action>
@@ -156,6 +162,9 @@
 								{#if status === "expired" || status === "unverified"}
 									<form class="contents" {...reverifyForm}>
 										<input type="hidden" name="emailId" value={email.id} />
+										{#if data.redirect}
+											<input type="hidden" name="redirect" value={data.redirect} />
+										{/if}
 										<DropdownMenu.Item
 											disabled={!!reverifyForm.pending}
 											data-testid="reverify-email"

--- a/src/routes/[locale=locale]/(app)/settings/emails/add/+page.server.ts
+++ b/src/routes/[locale=locale]/(app)/settings/emails/add/+page.server.ts
@@ -1,0 +1,12 @@
+import type { PageServerLoad } from "./$types";
+import { validateRedirectUrl } from "$lib/utils";
+
+export const load: PageServerLoad = async (event) => {
+	// Read and validate the redirect URL from query params
+	const redirectParam = event.url.searchParams.get("redirect");
+	const validatedRedirect = validateRedirectUrl(redirectParam);
+
+	return {
+		redirect: validatedRedirect,
+	};
+};

--- a/src/routes/[locale=locale]/(app)/settings/emails/add/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/settings/emails/add/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { PageProps } from "./$types";
 	import { LL, locale } from "$lib/i18n/i18n-svelte";
 	import { route } from "$lib/ROUTES";
 	import { Input } from "$lib/components/ui/input";
@@ -8,6 +9,8 @@
 	import * as Card from "$lib/components/ui/card/index.js";
 	import { addSecondaryEmailForm } from "$lib/api/secondary-emails.remote";
 	import { addSecondaryEmailSchema } from "$lib/api/secondary-emails.schema";
+
+	const { data }: PageProps = $props();
 
 	// Track if form has been validated (after first blur or submit attempt)
 	let hasValidated = $state(false);
@@ -35,6 +38,9 @@
 		</Alert.Root>
 
 		<form {...addSecondaryEmailForm.preflight(addSecondaryEmailSchema)} class="space-y-4">
+			{#if data.redirect}
+				<input type="hidden" name="redirect" value={data.redirect} />
+			{/if}
 			<div class="space-y-2">
 				<Label for="email">{$LL.secondaryEmail.emailAddress()}</Label>
 				<Input


### PR DESCRIPTION
## Summary
This PR adds support for redirecting users back to their original page after completing email verification, improving the user experience when email verification is required during workflows like membership signup.

## Key Changes

- **Redirect URL validation**: Added `validateRedirectUrl()` utility function in `src/lib/utils.ts` that safely validates redirect URLs to prevent open redirect vulnerabilities. Only allows pathname-only redirects (e.g., `/path?query=value`).

- **Email verification forms**: Updated `addSecondaryEmailForm` and `reverifySecondaryEmailForm` to accept an optional `redirect` parameter and store validated redirect URLs in secure HTTP-only cookies (`email_verify_redirect`).

- **Verification completion**: Modified the email verification completion flow (`verify/data.remote.ts`) to read the stored redirect URL from the cookie and redirect users to that URL instead of always returning to the emails management page.

- **Form state restoration**: Enhanced the membership signup page (`/new`) to:
  - Accept a `membershipId` query parameter for form pre-selection after redirect
  - Build redirect URLs that preserve the selected membership ID when navigating to email verification
  - Pre-select the membership radio button when returning from email verification

- **UI integration**: Updated email management pages to:
  - Pass redirect parameters through links and forms
  - Build dynamic redirect URLs that include the current page state
  - Preserve redirect context across the entire verification flow

## Implementation Details

- Redirect URLs are validated on both server-side (during form submission and page load) and stored in secure, HTTP-only cookies with the same expiration as the OTP
- Cookies are properly cleaned up after verification completes or is cancelled
- The validation function blocks protocol-relative URLs (`//`), backslashes, and protocol handlers to prevent security issues
- Redirect parameters are optional and gracefully handled with fallback behavior

https://claude.ai/code/session_011BZ3mUXMzV76aXy8euRDeB