### PR TITLE
feat: add feedback reporting system via Telegram

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,9 @@ MAILGUN_URL="https://api.eu.mailgun.net"
 # Azure docs: https://github.com/Azure/app-service-linux-docs/blob/master/Things_You_Should_Know/headers.md
 # Reference: https://learn.microsoft.com/en-us/answers/questions/819540/documentation-on-x-client-ip-http-header
 ADDRESS_HEADER=X-Client-IP
+
+# Telegram (optional - for feedback reporting)
+# Create a bot via @BotFather and get the token
+# Get chat ID by adding the bot to a group and using https://api.telegram.org/bot<token>/getUpdates
+TELEGRAM_BOT_TOKEN=""
+TELEGRAM_CHAT_ID=""

--- a/src/lib/components/feedback-form.svelte
+++ b/src/lib/components/feedback-form.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	import { page } from "$app/state";
+	import { LL } from "$lib/i18n/i18n-svelte";
+	import { Button } from "$lib/components/ui/button/index.js";
+	import { Label } from "$lib/components/ui/label/index.js";
+
+	interface Props {
+		errorCode?: string | number;
+	}
+
+	let { errorCode }: Props = $props();
+
+	let isOpen = $state(false);
+	let message = $state("");
+	let isSubmitting = $state(false);
+	let submitted = $state(false);
+	let errorMessage = $state("");
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+
+		if (!message.trim()) return;
+
+		isSubmitting = true;
+		errorMessage = "";
+
+		try {
+			const response = await fetch("/api/feedback", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					message: message.trim(),
+					pageUrl: page.url.href,
+					errorCode: errorCode?.toString(),
+					userAgent: navigator.userAgent,
+				}),
+			});
+
+			if (!response.ok) {
+				errorMessage = response.status === 429 ? $LL.feedback.rateLimited() : $LL.feedback.submitError();
+				return;
+			}
+
+			submitted = true;
+			message = "";
+		} catch {
+			errorMessage = $LL.feedback.submitError();
+		} finally {
+			isSubmitting = false;
+		}
+	}
+
+	function reset() {
+		submitted = false;
+		errorMessage = "";
+		message = "";
+	}
+</script>
+
+<div class="mt-6 w-full">
+	<Button variant="ghost" size="sm" class="text-muted-foreground" onclick={() => (isOpen = !isOpen)}>
+		{isOpen ? $LL.feedback.close() : $LL.feedback.reportIssue()}
+	</Button>
+
+	{#if isOpen}
+		<div class="mt-4">
+			{#if submitted}
+				<div class="rounded-lg border bg-muted/50 p-4 text-center">
+					<p class="text-sm text-muted-foreground">{$LL.feedback.thankYou()}</p>
+					<Button variant="ghost" size="sm" class="mt-2" onclick={reset}>
+						{$LL.feedback.sendAnother()}
+					</Button>
+				</div>
+			{:else}
+				<form onsubmit={handleSubmit} class="space-y-3">
+					<div class="space-y-2">
+						<Label for="feedback-message">{$LL.feedback.message()}</Label>
+						<textarea
+							id="feedback-message"
+							bind:value={message}
+							placeholder={$LL.feedback.placeholder()}
+							required
+							maxlength="2000"
+							rows="3"
+							class="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+						></textarea>
+					</div>
+
+					{#if errorMessage}
+						<p class="text-sm text-destructive">{errorMessage}</p>
+					{/if}
+
+					<div class="flex justify-end gap-2">
+						<Button type="button" variant="ghost" size="sm" onclick={() => (isOpen = false)}>
+							{$LL.common.cancel()}
+						</Button>
+						<Button type="submit" size="sm" disabled={isSubmitting || !message.trim()}>
+							{isSubmitting ? $LL.feedback.sending() : $LL.feedback.send()}
+						</Button>
+					</div>
+				</form>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/src/lib/i18n/en/index.ts
+++ b/src/lib/i18n/en/index.ts
@@ -500,6 +500,20 @@ const en = {
 		tryAgain: "Try again",
 	},
 
+	// Feedback
+	feedback: {
+		reportIssue: "Report an issue",
+		close: "Close",
+		message: "Message",
+		placeholder: "Describe the issue or give feedback...",
+		send: "Send",
+		sending: "Sending...",
+		thankYou: "Thank you for your feedback!",
+		sendAnother: "Send another",
+		submitError: "Failed to submit feedback. Please try again later.",
+		rateLimited: "Too many requests. Please try again later.",
+	},
+
 	// Documents & Legal
 	documents: {
 		footer: {

--- a/src/lib/i18n/fi/index.ts
+++ b/src/lib/i18n/fi/index.ts
@@ -501,6 +501,20 @@ const fi = {
 		tryAgain: "Yritä uudelleen",
 	},
 
+	// Feedback
+	feedback: {
+		reportIssue: "Ilmoita ongelmasta",
+		close: "Sulje",
+		message: "Viesti",
+		placeholder: "Kuvaile ongelma tai anna palautetta...",
+		send: "Lähetä",
+		sending: "Lähetetään...",
+		thankYou: "Kiitos palautteestasi!",
+		sendAnother: "Lähetä uusi",
+		submitError: "Palautteen lähetys epäonnistui. Yritä myöhemmin uudelleen.",
+		rateLimited: "Liian monta pyyntöä. Yritä myöhemmin uudelleen.",
+	},
+
 	// Documents & Legal
 	documents: {
 		footer: {

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -98,6 +98,20 @@ const privateEnvSchema = v.pipe(
 		RP_NAME: v.pipe(v.string(), v.minLength(1)),
 		RP_ID: v.pipe(v.string(), v.minLength(1)),
 		RP_ORIGIN: v.pipe(v.string(), v.url(), v.regex(/^https?:\/\/.+/, "RP_ORIGIN must use http or https protocol")),
+
+		// Telegram (optional - for feedback reporting)
+		TELEGRAM_BOT_TOKEN: v.optional(
+			v.pipe(
+				v.string(),
+				v.transform((val) => (val === "" ? undefined : val)),
+			),
+		),
+		TELEGRAM_CHAT_ID: v.optional(
+			v.pipe(
+				v.string(),
+				v.transform((val) => (val === "" ? undefined : val)),
+			),
+		),
 	}),
 	// In production, Mailgun is required
 	v.check((data) => {
@@ -131,6 +145,8 @@ const parsed = v.safeParse(privateEnvSchema, {
 	RP_NAME: privateEnv.RP_NAME,
 	RP_ID: privateEnv.RP_ID,
 	RP_ORIGIN: privateEnv.RP_ORIGIN,
+	TELEGRAM_BOT_TOKEN: privateEnv.TELEGRAM_BOT_TOKEN,
+	TELEGRAM_CHAT_ID: privateEnv.TELEGRAM_CHAT_ID,
 });
 
 if (!parsed.success) {

--- a/src/lib/server/telegram.ts
+++ b/src/lib/server/telegram.ts
@@ -1,0 +1,75 @@
+import { env } from "$lib/server/env";
+
+interface SendMessageOptions {
+	message: string;
+	parseMode?: "HTML" | "Markdown" | "MarkdownV2";
+}
+
+/**
+ * Send a message to the configured Telegram chat via bot API.
+ * Returns true if successful, false otherwise.
+ */
+export async function sendTelegramMessage(options: SendMessageOptions): Promise<boolean> {
+	if (!env.TELEGRAM_BOT_TOKEN || !env.TELEGRAM_CHAT_ID) {
+		console.warn("[Telegram] Not configured, skipping message send");
+		return false;
+	}
+
+	try {
+		const url = `https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`;
+
+		const response = await fetch(url, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				chat_id: env.TELEGRAM_CHAT_ID,
+				text: options.message,
+				parse_mode: options.parseMode,
+			}),
+		});
+
+		if (!response.ok) {
+			const error = await response.text();
+			console.error("[Telegram] Failed to send message:", error);
+			return false;
+		}
+
+		return true;
+	} catch (error) {
+		console.error("[Telegram] Error sending message:", error);
+		return false;
+	}
+}
+
+/**
+ * Escape special characters for Telegram MarkdownV2 format.
+ */
+export function escapeMarkdownV2(text: string): string {
+	return text.replaceAll(/[_*[\]()~`>#+\-=|{}.!\\]/g, String.raw`\$&`);
+}
+
+/**
+ * Health check for Telegram bot connectivity.
+ */
+export async function checkTelegramHealth(): Promise<"ok" | "not_configured" | "error"> {
+	if (env.CI || !env.TELEGRAM_BOT_TOKEN || !env.TELEGRAM_CHAT_ID) {
+		return "not_configured";
+	}
+
+	try {
+		const url = `https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/getMe`;
+		const response = await fetch(url);
+
+		if (!response.ok) {
+			console.error("[Telegram] Health check failed:", await response.text());
+			return "error";
+		}
+
+		return "ok";
+	} catch (error) {
+		console.error("[Telegram] Health check error:", error);
+		return "error";
+	}
+}

--- a/src/routes/[locale=locale]/+error.svelte
+++ b/src/routes/[locale=locale]/+error.svelte
@@ -4,6 +4,7 @@
 	import { route } from "$lib/ROUTES";
 	import * as Card from "$lib/components/ui/card/index.js";
 	import { Button } from "$lib/components/ui/button/index.js";
+	import FeedbackForm from "$lib/components/feedback-form.svelte";
 
 	const is404 = $derived(page.status === 404);
 	const is5xx = $derived(page.status >= 500 && page.status < 600);
@@ -53,6 +54,8 @@
 					<pre class="mt-2 overflow-auto rounded-lg bg-muted p-4 text-xs">{JSON.stringify(page.error, null, 2)}</pre>
 				</details>
 			{/if}
+
+			<FeedbackForm errorCode={page.status} />
 		</Card.Content>
 	</Card.Root>
 </div>

--- a/src/routes/api/feedback/+server.ts
+++ b/src/routes/api/feedback/+server.ts
@@ -1,0 +1,85 @@
+import { json, error } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+import * as v from "valibot";
+import { sendTelegramMessage, escapeMarkdownV2 } from "$lib/server/telegram";
+import { env } from "$lib/server/env";
+import { RefillingTokenBucket } from "$lib/server/auth/rate-limit";
+
+const feedbackSchema = v.object({
+	message: v.pipe(v.string(), v.minLength(1, "Message is required"), v.maxLength(2000, "Message too long")),
+	pageUrl: v.optional(v.pipe(v.string(), v.maxLength(500))),
+	errorCode: v.optional(v.pipe(v.string(), v.maxLength(10))),
+	userAgent: v.optional(v.pipe(v.string(), v.maxLength(500))),
+});
+
+// Rate limit: 5 feedback submissions per hour per IP
+const ipBucket = new RefillingTokenBucket<string>(5, 60 * 60);
+
+export const POST: RequestHandler = async ({ request, locals, getClientAddress }) => {
+	const clientIP = getClientAddress();
+
+	// Check rate limit (skip if disabled for tests)
+	if (!env.UNSAFE_DISABLE_RATE_LIMITS && !ipBucket.consume(clientIP, 1)) {
+		error(429, "Too many feedback submissions. Please try again later.");
+	}
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		error(400, "Invalid JSON body");
+	}
+
+	const parsed = v.safeParse(feedbackSchema, body);
+	if (!parsed.success) {
+		error(400, "Invalid feedback data");
+	}
+
+	const { message, pageUrl, errorCode, userAgent } = parsed.output;
+
+	// Build Telegram message
+	const userInfo = locals.user ? `${locals.user.email} (${locals.user.id})` : "Anonymous";
+
+	const lines = [
+		"📣 *New Feedback Report*",
+		"",
+		`*From:* ${escapeMarkdownV2(userInfo)}`,
+		`*IP:* ${escapeMarkdownV2(clientIP)}`,
+	];
+
+	if (pageUrl) {
+		lines.push(`*Page:* ${escapeMarkdownV2(pageUrl)}`);
+	}
+
+	if (errorCode) {
+		lines.push(`*Error Code:* ${escapeMarkdownV2(errorCode)}`);
+	}
+
+	if (userAgent) {
+		// Truncate user agent if too long
+		const truncatedUA = userAgent.length > 100 ? userAgent.slice(0, 100) + "..." : userAgent;
+		lines.push(`*User Agent:* ${escapeMarkdownV2(truncatedUA)}`);
+	}
+
+	lines.push("", "*Message:*", escapeMarkdownV2(message));
+
+	const telegramMessage = lines.join("\n");
+
+	const sent = await sendTelegramMessage({
+		message: telegramMessage,
+		parseMode: "MarkdownV2",
+	});
+
+	if (!sent) {
+		// Log the feedback anyway even if Telegram fails
+		console.log("[Feedback] Received feedback (Telegram not configured or failed):", {
+			user: userInfo,
+			ip: clientIP,
+			pageUrl,
+			errorCode,
+			message,
+		});
+	}
+
+	return json({ success: true });
+};


### PR DESCRIPTION
Add a feedback form component that allows users to report issues
from error pages. Feedback is sent to a configured Telegram chat
using a bot.

- Add Telegram bot service for sending messages
- Add feedback API endpoint with rate limiting
- Add feedback form component to error pages
- Add i18n translations (Finnish and English)
- Add TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID env vars

https://claude.ai/code/session_01T8hLZJhqjJissBdJHUzTJh