### PR TITLE
fix: improve user merge validation and error handling

### DIFF
--- a/src/routes/[locale=locale]/(app)/admin/users/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/admin/users/+page.svelte
@@ -100,7 +100,14 @@
 				await invalidateAll();
 			}
 		} catch (err) {
-			const errorMessage = err instanceof Error ? err.message : "Unknown error";
+			// Handle SvelteKit error responses
+			let errorMessage = "Unknown error";
+			if (err && typeof err === "object" && "error" in err) {
+				const errorObj = err.error as { message?: string };
+				errorMessage = errorObj.message ?? "Unknown error";
+			} else if (err instanceof Error) {
+				errorMessage = err.message;
+			}
 			toast.error(errorMessage);
 		} finally {
 			mergeInProgress = false;
@@ -291,14 +298,6 @@
 									<li>{$LL.admin.users.merge.passkeys()}</li>
 									<li>{$LL.admin.users.merge.sessions()}</li>
 								</ul>
-							</Alert.Description>
-						</Alert.Root>
-
-						<Alert.Root variant="default">
-							<AlertCircle class="size-4" />
-							<Alert.Title>{$LL.admin.users.merge.noOverlappingMemberships()}</Alert.Title>
-							<Alert.Description>
-								{$LL.admin.users.merge.checkingMemberships()}
 							</Alert.Description>
 						</Alert.Root>
 


### PR DESCRIPTION
## Summary
This PR improves the user merge functionality by refining membership overlap validation logic and enhancing error handling for SvelteKit error responses.

## Key Changes
- **Enhanced error handling**: Updated error catching in the merge users handler to properly detect and extract error messages from SvelteKit error response objects, in addition to standard Error instances
- **Refined membership validation**: Modified the overlapping membership check to only consider memberships with "blocking" statuses (e.g., active, pending) while ignoring cancelled and expired memberships that should not prevent a merge
- **Removed redundant UI**: Removed an informational alert about membership checking that is no longer needed with the updated validation logic

## Implementation Details
- Added import of `BLOCKING_MEMBER_STATUSES` enum to filter memberships before overlap validation
- The error handling now checks for SvelteKit's error response format (`{ error: { message } }`) before falling back to standard Error handling
- Membership filtering is applied to both primary and secondary user memberships before the overlap check, reducing unnecessary iterations and improving clarity of intent

https://claude.ai/code/session_01MYusaLJVwz9jzdSK5eB1dL