### PR TITLE
feat: display user name on membership card

### DIFF
--- a/src/lib/components/membership-card.svelte
+++ b/src/lib/components/membership-card.svelte
@@ -31,9 +31,10 @@
 
 	interface Props {
 		memberships: Membership[];
+		userName: string;
 	}
 
-	let { memberships }: Props = $props();
+	let { memberships, userName }: Props = $props();
 
 	// Helper to get localized membership type name
 	function getTypeName(membershipType: MembershipType): string {
@@ -126,6 +127,7 @@
 	<Card.Content class="space-y-4">
 		{#if currentMembership}
 			<div class="space-y-1">
+				<p class="text-lg font-medium">{userName}</p>
 				<p class="text-2xl font-semibold">{getTypeName(currentMembership.membershipType)}</p>
 				<p class="text-sm text-muted-foreground">
 					<time datetime={currentMembership.startTime.toISOString()}>

--- a/src/routes/[locale=locale]/(app)/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/+page.svelte
@@ -35,7 +35,7 @@
 
 <div class="container mx-auto max-w-2xl px-4 py-8">
 	{#if isProfileComplete}
-		<MembershipCard memberships={data.memberships} />
+		<MembershipCard memberships={data.memberships} userName="{data.user.firstNames} {data.user.lastName}" />
 	{:else}
 		<ProfileIncompleteCard />
 	{/if}


### PR DESCRIPTION
## Summary
Added the ability to display the user's name on the membership card component, providing better personalization of the membership information display.

## Changes
- **membership-card.svelte**: 
  - Added `userName` prop to the component's Props interface
  - Updated component destructuring to include the new `userName` prop
  - Rendered user's full name above the membership type in the card content

- **+page.svelte**: 
  - Passed user's full name (first names + last name) to the MembershipCard component from the page data

## Implementation Details
The user's full name is constructed by concatenating `data.user.firstNames` and `data.user.lastName` and passed directly to the component. The name is displayed as a medium-weight text element above the membership type, providing a clear visual hierarchy on the card.

https://claude.ai/code/session_012X23MNaieYDd2MznTrod7e