### PR TITLE
feat: add Textarea component and integrate into membership form

### DIFF
--- a/src/lib/components/ui/textarea/index.ts
+++ b/src/lib/components/ui/textarea/index.ts
@@ -1,0 +1,1 @@
+export { default as Textarea } from "./textarea.svelte";

--- a/src/lib/components/ui/textarea/textarea.svelte
+++ b/src/lib/components/ui/textarea/textarea.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { HTMLTextareaAttributes } from "svelte/elements";
+  import { cn, type WithElementRef } from "$lib/utils.js";
+
+  type Props = WithElementRef<HTMLTextareaAttributes, HTMLTextAreaElement>;
+
+  let { ref = $bindable(null), value = $bindable(), class: className, ...restProps }: Props = $props();
+</script>
+
+<textarea
+  bind:this={ref}
+  data-slot="textarea"
+  class={cn(
+    "flex field-sizing-content min-h-16 w-full min-w-0 rounded-md border border-input bg-background px-3 py-2 text-base shadow-xs ring-offset-background transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+    "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+    "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+    className,
+  )}
+  bind:value
+  {...restProps}
+></textarea>

--- a/src/routes/[locale=locale]/(app)/new/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/new/+page.svelte
@@ -13,6 +13,7 @@
   import { payMembershipSchema } from "./schema";
   import { getStripePriceMetadata } from "$lib/api/stripe.remote";
   import { formatPrice } from "$lib/utils";
+  import { Textarea } from "$lib/components/ui/textarea";
   import { BLOCKING_MEMBER_STATUSES } from "$lib/shared/enums";
 
   const { data }: PageProps = $props();
@@ -108,22 +109,23 @@
             </a>
           </div>
 
-          <div class="space-y-2">
-            <label for="description" class="text-sm font-medium">
-              {$LL.membership.description()}
-              {#if requireStudentVerification}
-                <span class="font-normal text-muted-foreground">({$LL.common.optional()})</span>
-              {/if}
-            </label>
-            <textarea
-              id="description"
-              name="description"
-              rows="3"
-              required={!requireStudentVerification}
-              placeholder={$LL.membership.descriptionPlaceholder()}
-              class="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-            ></textarea>
-          </div>
+          {#if payMembership.fields.membershipId.value()}
+            <div class="space-y-2">
+              <label for="description" class="text-sm font-medium">
+                {$LL.membership.description()}
+                {#if requireStudentVerification}
+                  <span class="font-normal text-muted-foreground">({$LL.common.optional()})</span>
+                {/if}
+              </label>
+              <Textarea
+                id="description"
+                name="description"
+                rows={3}
+                required={!requireStudentVerification}
+                placeholder={$LL.membership.descriptionPlaceholder()}
+              />
+            </div>
+          {/if}
 
           {#if requireStudentVerification}
             <div class="space-y-3">


### PR DESCRIPTION
## Summary
This PR introduces a new reusable `Textarea` UI component and integrates it into the membership creation form, replacing the inline textarea element with the new component.

## Key Changes
- **New Textarea Component**: Created a new `Textarea` component (`src/lib/components/ui/textarea/`) with:
  - Full TypeScript support with proper element ref binding
  - Comprehensive styling including focus states, disabled states, and error states (aria-invalid)
  - Support for dark mode
  - Proper accessibility attributes and selection styling
  - Bindable `value` prop for reactive form handling

- **Membership Form Integration**: Updated the membership creation form to:
  - Import and use the new `Textarea` component
  - Wrap the textarea section in a conditional block that only displays when a membership is selected
  - Simplify the textarea markup by removing inline styles in favor of the component's built-in styling

## Implementation Details
- The Textarea component uses Svelte 5's `$bindable()` for two-way binding on both `ref` and `value`
- Styling includes field-sizing-content for better height management and comprehensive focus/invalid states
- The component properly spreads remaining HTML attributes to support all standard textarea properties
- The form integration adds a conditional check (`{#if payMembership.fields.membershipId.value()}`) to only show the description field when a membership is selected

https://claude.ai/code/session_01J3neFw3reHiwXfibd3EnbY