### PR TITLE
fix: catch validate() rejection when form unmounts during navigation

### DIFF
--- a/src/routes/[locale=locale]/(app)/settings/emails/add/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/settings/emails/add/+page.svelte
@@ -17,13 +17,14 @@
 
   function handleBlur() {
     hasValidated = true;
-    addSecondaryEmailForm.validate();
+    // validate() may reject if the form unmounts during navigation (e.g. after submit redirect)
+    addSecondaryEmailForm.validate().catch(() => {});
   }
 
   function handleInput() {
     // Only validate on input after initial validation (reward early, validate late)
     if (hasValidated) {
-      addSecondaryEmailForm.validate();
+      addSecondaryEmailForm.validate().catch(() => {});
     }
   }
 </script>


### PR DESCRIPTION
## Summary
- Catch unhandled promise rejection from `addSecondaryEmailForm.validate()` in the add-email page
- The form's `validate()` method rejects with a `FormData` TypeError when the form component unmounts during navigation (e.g. after submit redirect), because SvelteKit's internal `validate()` checks `!element` before `await tick()` but not after
- The error is functionally benign but noisy in the dev console

## Test plan
- [ ] Navigate to add secondary email page, enter an email, and submit — verify no console error
- [ ] Verify form validation still works on blur/input before submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)