### PR TITLE
feat: add automatic membership renewal approval for consecutive periods

### DIFF
--- a/src/lib/i18n/en/index.ts
+++ b/src/lib/i18n/en/index.ts
@@ -249,6 +249,10 @@ const en = {
     alreadyHaveMembershipForPeriod: "You already have a membership for this period",
     noAvailableMemberships:
       "No memberships available for purchase. You already have a membership for all available periods.",
+    willAutoApprove: "Will be automatically approved after payment",
+    willRequireApproval: "Will require board approval after payment",
+    autoApprovalAdminNote:
+      "Members who had an approved membership of the same type in the immediately preceding period will be automatically approved upon renewal. For student memberships, a valid aalto.fi email is also required.",
 
     // Status
     status: {

--- a/src/lib/i18n/fi/index.ts
+++ b/src/lib/i18n/fi/index.ts
@@ -249,6 +249,10 @@ const fi = {
     alreadyHaveMembershipForPeriod: "Sinulla on jo jäsenyys tälle ajanjaksolle",
     noAvailableMemberships:
       "Ei ostettavia jäsenyyksiä. Sinulla on jo jäsenyys kaikille saatavilla oleville ajanjaksoille.",
+    willAutoApprove: "Hyväksytään automaattisesti maksun jälkeen",
+    willRequireApproval: "Vaatii hallituksen hyväksynnän maksun jälkeen",
+    autoApprovalAdminNote:
+      "Jäsenet, joilla on hyväksytty jäsenyys samaa tyyppiä edellisellä kaudella, hyväksytään automaattisesti uusiessaan jäsenyytensä. Opiskelijajäsenyyksien automaattinen hyväksyntä edellyttää myös voimassa olevaa aalto.fi-sähköpostia.",
 
     // Status
     status: {

--- a/src/lib/server/audit.ts
+++ b/src/lib/server/audit.ts
@@ -10,6 +10,7 @@ export type AuditAction =
   | "auth.passkey_registered"
   | "auth.passkey_deleted"
   | "member.approve"
+  | "member.auto_approve"
   | "member.reject"
   | "member.expire"
   | "member.cancel"

--- a/src/lib/server/payment/auto-approval.ts
+++ b/src/lib/server/payment/auto-approval.ts
@@ -1,0 +1,111 @@
+import { and, eq, lte, desc, inArray } from "drizzle-orm";
+import * as table from "$lib/server/db/schema";
+import type { Membership, SecondaryEmail } from "$lib/server/db/schema";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+
+type DbHandle = PostgresJsDatabase<typeof table>;
+
+/** Maximum gap (in ms) between preceding period end and new period start for auto-approval. */
+const MAX_PRECEDING_GAP_MS = 6 * 30 * 24 * 60 * 60 * 1000; // ~6 months
+
+/**
+ * Check if a user is eligible for auto-approval when purchasing a membership.
+ *
+ * Auto-approval is granted when:
+ * 1. The user had an approved membership (active or expired) of the same membership type
+ *    in the immediately preceding period (gap must be at most ~6 months)
+ * 2. For student-verified memberships: the user still has a valid aalto.fi email
+ *
+ * @param db - Database handle (can be a transaction or regular db)
+ * @param userId - The user purchasing the membership
+ * @param newMembership - The membership being purchased
+ */
+export async function checkAutoApprovalEligibility(
+  db: DbHandle,
+  userId: string,
+  newMembership: Membership,
+): Promise<boolean> {
+  // Find the immediately preceding membership of the same type
+  // (same membershipTypeId, endTime <= newMembership.startTime, most recent)
+  const precedingMembership = await db.query.membership.findFirst({
+    where: and(
+      eq(table.membership.membershipTypeId, newMembership.membershipTypeId),
+      lte(table.membership.endTime, newMembership.startTime),
+    ),
+    orderBy: desc(table.membership.endTime),
+  });
+
+  if (!precedingMembership) {
+    return false;
+  }
+
+  // Ensure the preceding period is actually adjacent (gap at most ~6 months)
+  const gapMs = newMembership.startTime.getTime() - precedingMembership.endTime.getTime();
+  if (gapMs > MAX_PRECEDING_GAP_MS) {
+    return false;
+  }
+
+  // Check if user had an approved member record for that preceding membership
+  // "active" or "expired" status indicates the board approved it at some point
+  const previousMember = await db.query.member.findFirst({
+    where: and(
+      eq(table.member.userId, userId),
+      eq(table.member.membershipId, precedingMembership.id),
+      inArray(table.member.status, ["active", "expired"]),
+    ),
+  });
+
+  if (!previousMember) {
+    return false;
+  }
+
+  // If student verification is required, check for valid aalto.fi email
+  if (newMembership.requiresStudentVerification) {
+    const hasValidStudentEmail = await checkStudentEmail(db, userId);
+    if (!hasValidStudentEmail) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Check if a user has a valid aalto.fi email (primary or verified secondary).
+ */
+async function checkStudentEmail(db: DbHandle, userId: string): Promise<boolean> {
+  // Check primary email
+  const user = await db.query.user.findFirst({
+    where: eq(table.user.id, userId),
+    columns: { email: true },
+  });
+
+  if (!user) {
+    return false;
+  }
+
+  const primaryDomain = user.email.split("@")[1]?.toLowerCase();
+  if (primaryDomain === "aalto.fi") {
+    return true;
+  }
+
+  // Check secondary emails using the passed db handle, filtering at DB level
+  const aaltoEmails = await db
+    .select({
+      verifiedAt: table.secondaryEmail.verifiedAt,
+      expiresAt: table.secondaryEmail.expiresAt,
+    })
+    .from(table.secondaryEmail)
+    .where(and(eq(table.secondaryEmail.userId, userId), eq(table.secondaryEmail.domain, "aalto.fi")));
+  return aaltoEmails.some((e) => isEmailValid(e));
+}
+
+/**
+ * Check if a secondary email is currently valid (verified and not expired).
+ * Inlined to avoid transitive dependency on $app/environment via secondary-email.ts.
+ */
+function isEmailValid(email: Pick<SecondaryEmail, "verifiedAt" | "expiresAt">): boolean {
+  if (!email.verifiedAt) return false;
+  if (!email.expiresAt) return true;
+  return email.expiresAt > new Date();
+}

--- a/src/routes/[locale=locale]/(app)/admin/memberships/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/admin/memberships/+page.svelte
@@ -77,6 +77,8 @@
     {/snippet}
   </AdminPageHeader>
 
+  <p class="mb-6 text-sm text-muted-foreground">{$LL.membership.autoApprovalAdminNote()}</p>
+
   {#if data.memberships.length === 0}
     <!-- Empty state -->
     <Empty.Root class="border">

--- a/src/routes/[locale=locale]/(app)/new/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/new/+page.svelte
@@ -164,6 +164,11 @@
                     {new Date(membership.startTime).toLocaleDateString(`${$locale}-FI`)}
                     – {new Date(membership.endTime).toLocaleDateString(`${$locale}-FI`)}
                   </span>
+                  {#if membership.willAutoApprove}
+                    <span class="text-xs text-green-600 dark:text-green-400">{$LL.membership.willAutoApprove()}</span>
+                  {:else}
+                    <span class="text-xs text-muted-foreground">{$LL.membership.willRequireApproval()}</span>
+                  {/if}
                   {#if typeDescription}
                     <span class="text-sm text-muted-foreground">{typeDescription}</span>
                   {/if}

--- a/tests/auto-approval.test.ts
+++ b/tests/auto-approval.test.ts
@@ -1,0 +1,457 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createTestDatabase, stopTestDatabase, type TestDatabase } from "./utils/db";
+import * as table from "../src/lib/server/db/schema";
+import { checkAutoApprovalEligibility } from "../src/lib/server/payment/auto-approval";
+
+// Helper to create a membership type
+async function createMembershipType(db: TestDatabase["db"], id: string) {
+  await db.insert(table.membershipType).values({
+    id,
+    name: { fi: `Tyyppi ${id}`, en: `Type ${id}` },
+  });
+}
+
+// Helper to create a membership period
+async function createMembership(
+  db: TestDatabase["db"],
+  opts: {
+    id: string;
+    membershipTypeId: string;
+    startTime: Date;
+    endTime: Date;
+    requiresStudentVerification?: boolean;
+  },
+) {
+  await db.insert(table.membership).values({
+    id: opts.id,
+    membershipTypeId: opts.membershipTypeId,
+    startTime: opts.startTime,
+    endTime: opts.endTime,
+    requiresStudentVerification: opts.requiresStudentVerification ?? false,
+  });
+}
+
+// Helper to create a user
+async function createUser(db: TestDatabase["db"], opts: { id: string; email: string }) {
+  await db.insert(table.user).values({
+    id: opts.id,
+    email: opts.email,
+    isAdmin: false,
+  });
+}
+
+// Helper to create a member record
+async function createMember(
+  db: TestDatabase["db"],
+  opts: {
+    userId: string;
+    membershipId: string;
+    status: "awaiting_payment" | "awaiting_approval" | "active" | "expired" | "cancelled";
+  },
+) {
+  await db.insert(table.member).values({
+    id: crypto.randomUUID(),
+    userId: opts.userId,
+    membershipId: opts.membershipId,
+    status: opts.status,
+  });
+}
+
+// Helper to create a secondary email
+async function createSecondaryEmail(
+  db: TestDatabase["db"],
+  opts: {
+    userId: string;
+    email: string;
+    domain: string;
+    verifiedAt: Date | null;
+    expiresAt: Date | null;
+  },
+) {
+  await db.insert(table.secondaryEmail).values({
+    id: crypto.randomUUID(),
+    userId: opts.userId,
+    email: opts.email,
+    domain: opts.domain,
+    verifiedAt: opts.verifiedAt,
+    expiresAt: opts.expiresAt,
+  });
+}
+
+// Helper to fetch a membership by ID with assertion
+async function getMembership(db: TestDatabase["db"], id: string) {
+  const membership = await db.query.membership.findFirst({
+    where: (m, { eq }) => eq(m.id, id),
+  });
+  if (!membership) throw new Error(`Membership ${id} not found`);
+  return membership;
+}
+
+describe("Auto-approval eligibility", () => {
+  let testDb: TestDatabase;
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase();
+  }, 120_000);
+
+  afterAll(async () => {
+    await stopTestDatabase(testDb);
+  });
+
+  it("auto-approves when user has active membership of same type in preceding period", async () => {
+    const { db } = testDb;
+    const userId = crypto.randomUUID();
+    const typeId = `type-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createMembershipType(db, typeId);
+    await createUser(db, { id: userId, email: `${userId}@example.com` });
+
+    // Previous period
+    await createMembership(db, {
+      id: `prev-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2024-01-01"),
+      endTime: new Date("2024-12-31"),
+    });
+    await createMember(db, { userId, membershipId: `prev-${userId}`, status: "active" });
+
+    // New period
+    await createMembership(db, {
+      id: `new-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2025-01-01"),
+      endTime: new Date("2025-12-31"),
+    });
+
+    const newMembership = await getMembership(db, `new-${userId}`);
+
+    const result = await checkAutoApprovalEligibility(db, userId, newMembership);
+    expect(result).toBe(true);
+  });
+
+  it("auto-approves when previous membership status is expired", async () => {
+    const { db } = testDb;
+    const userId = crypto.randomUUID();
+    const typeId = `type-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createMembershipType(db, typeId);
+    await createUser(db, { id: userId, email: `${userId}@example.com` });
+
+    await createMembership(db, {
+      id: `prev-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2024-01-01"),
+      endTime: new Date("2024-12-31"),
+    });
+    await createMember(db, { userId, membershipId: `prev-${userId}`, status: "expired" });
+
+    await createMembership(db, {
+      id: `new-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2025-01-01"),
+      endTime: new Date("2025-12-31"),
+    });
+
+    const newMembership = await getMembership(db, `new-${userId}`);
+
+    const result = await checkAutoApprovalEligibility(db, userId, newMembership);
+    expect(result).toBe(true);
+  });
+
+  it("rejects when user has no previous memberships", async () => {
+    const { db } = testDb;
+    const userId = crypto.randomUUID();
+    const typeId = `type-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createMembershipType(db, typeId);
+    await createUser(db, { id: userId, email: `${userId}@example.com` });
+
+    await createMembership(db, {
+      id: `new-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2025-01-01"),
+      endTime: new Date("2025-12-31"),
+    });
+
+    const newMembership = await getMembership(db, `new-${userId}`);
+
+    const result = await checkAutoApprovalEligibility(db, userId, newMembership);
+    expect(result).toBe(false);
+  });
+
+  it("rejects when previous membership is a different type", async () => {
+    const { db } = testDb;
+    const userId = crypto.randomUUID();
+    const typeA = `type-a-${crypto.randomUUID().slice(0, 8)}`;
+    const typeB = `type-b-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createMembershipType(db, typeA);
+    await createMembershipType(db, typeB);
+    await createUser(db, { id: userId, email: `${userId}@example.com` });
+
+    // Previous period - different type
+    await createMembership(db, {
+      id: `prev-${userId}`,
+      membershipTypeId: typeA,
+      startTime: new Date("2024-01-01"),
+      endTime: new Date("2024-12-31"),
+    });
+    await createMember(db, { userId, membershipId: `prev-${userId}`, status: "active" });
+
+    // New period - typeB
+    await createMembership(db, {
+      id: `new-${userId}`,
+      membershipTypeId: typeB,
+      startTime: new Date("2025-01-01"),
+      endTime: new Date("2025-12-31"),
+    });
+
+    const newMembership = await getMembership(db, `new-${userId}`);
+
+    const result = await checkAutoApprovalEligibility(db, userId, newMembership);
+    expect(result).toBe(false);
+  });
+
+  it("rejects when previous membership was cancelled", async () => {
+    const { db } = testDb;
+    const userId = crypto.randomUUID();
+    const typeId = `type-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createMembershipType(db, typeId);
+    await createUser(db, { id: userId, email: `${userId}@example.com` });
+
+    await createMembership(db, {
+      id: `prev-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2024-01-01"),
+      endTime: new Date("2024-12-31"),
+    });
+    await createMember(db, { userId, membershipId: `prev-${userId}`, status: "cancelled" });
+
+    await createMembership(db, {
+      id: `new-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2025-01-01"),
+      endTime: new Date("2025-12-31"),
+    });
+
+    const newMembership = await getMembership(db, `new-${userId}`);
+
+    const result = await checkAutoApprovalEligibility(db, userId, newMembership);
+    expect(result).toBe(false);
+  });
+
+  it("rejects when there is a gap in membership periods", async () => {
+    const { db } = testDb;
+    const userId = crypto.randomUUID();
+    const typeId = `type-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createMembershipType(db, typeId);
+    await createUser(db, { id: userId, email: `${userId}@example.com` });
+
+    // Period from 2 years ago (user had membership)
+    await createMembership(db, {
+      id: `old-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2023-01-01"),
+      endTime: new Date("2023-12-31"),
+    });
+    await createMember(db, { userId, membershipId: `old-${userId}`, status: "active" });
+
+    // Preceding period exists but user did NOT have a membership for it
+    await createMembership(db, {
+      id: `prev-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2024-01-01"),
+      endTime: new Date("2024-12-31"),
+    });
+    // No member record for prev period!
+
+    // New period
+    await createMembership(db, {
+      id: `new-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2025-01-01"),
+      endTime: new Date("2025-12-31"),
+    });
+
+    const newMembership = await getMembership(db, `new-${userId}`);
+
+    const result = await checkAutoApprovalEligibility(db, userId, newMembership);
+    expect(result).toBe(false);
+  });
+
+  it("rejects when user skipped a year (preceding period too far in the past)", async () => {
+    const { db } = testDb;
+    const userId = crypto.randomUUID();
+    const typeId = `type-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createMembershipType(db, typeId);
+    await createUser(db, { id: userId, email: `${userId}@example.com` });
+
+    // User had active membership in 2023
+    await createMembership(db, {
+      id: `old-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2023-01-01"),
+      endTime: new Date("2023-12-31"),
+    });
+    await createMember(db, { userId, membershipId: `old-${userId}`, status: "active" });
+
+    // No 2024 period exists at all — user tries to buy 2025
+    await createMembership(db, {
+      id: `new-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2025-01-01"),
+      endTime: new Date("2025-12-31"),
+    });
+
+    const newMembership = await getMembership(db, `new-${userId}`);
+
+    const result = await checkAutoApprovalEligibility(db, userId, newMembership);
+    expect(result).toBe(false);
+  });
+
+  it("auto-approves student membership with valid aalto.fi secondary email", async () => {
+    const { db } = testDb;
+    const userId = crypto.randomUUID();
+    const typeId = `type-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createMembershipType(db, typeId);
+    await createUser(db, { id: userId, email: `${userId}@example.com` });
+
+    // Valid aalto secondary email
+    await createSecondaryEmail(db, {
+      userId,
+      email: `${userId}@aalto.fi`,
+      domain: "aalto.fi",
+      verifiedAt: new Date("2025-01-01"),
+      expiresAt: new Date("2099-01-01"),
+    });
+
+    await createMembership(db, {
+      id: `prev-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2024-01-01"),
+      endTime: new Date("2024-12-31"),
+      requiresStudentVerification: true,
+    });
+    await createMember(db, { userId, membershipId: `prev-${userId}`, status: "active" });
+
+    await createMembership(db, {
+      id: `new-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2025-01-01"),
+      endTime: new Date("2025-12-31"),
+      requiresStudentVerification: true,
+    });
+
+    const newMembership = await getMembership(db, `new-${userId}`);
+
+    const result = await checkAutoApprovalEligibility(db, userId, newMembership);
+    expect(result).toBe(true);
+  });
+
+  it("rejects student membership with expired aalto.fi secondary email", async () => {
+    const { db } = testDb;
+    const userId = crypto.randomUUID();
+    const typeId = `type-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createMembershipType(db, typeId);
+    await createUser(db, { id: userId, email: `${userId}@example.com` });
+
+    // Expired aalto secondary email
+    await createSecondaryEmail(db, {
+      userId,
+      email: `${userId}@aalto.fi`,
+      domain: "aalto.fi",
+      verifiedAt: new Date("2024-01-01"),
+      expiresAt: new Date("2024-07-01"), // expired
+    });
+
+    await createMembership(db, {
+      id: `prev-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2024-01-01"),
+      endTime: new Date("2024-12-31"),
+      requiresStudentVerification: true,
+    });
+    await createMember(db, { userId, membershipId: `prev-${userId}`, status: "active" });
+
+    await createMembership(db, {
+      id: `new-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2025-01-01"),
+      endTime: new Date("2025-12-31"),
+      requiresStudentVerification: true,
+    });
+
+    const newMembership = await getMembership(db, `new-${userId}`);
+
+    const result = await checkAutoApprovalEligibility(db, userId, newMembership);
+    expect(result).toBe(false);
+  });
+
+  it("auto-approves student membership with aalto.fi primary email", async () => {
+    const { db } = testDb;
+    const userId = crypto.randomUUID();
+    const typeId = `type-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createMembershipType(db, typeId);
+    await createUser(db, { id: userId, email: `${userId}@aalto.fi` });
+
+    await createMembership(db, {
+      id: `prev-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2024-01-01"),
+      endTime: new Date("2024-12-31"),
+      requiresStudentVerification: true,
+    });
+    await createMember(db, { userId, membershipId: `prev-${userId}`, status: "active" });
+
+    await createMembership(db, {
+      id: `new-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2025-01-01"),
+      endTime: new Date("2025-12-31"),
+      requiresStudentVerification: true,
+    });
+
+    const newMembership = await getMembership(db, `new-${userId}`);
+
+    const result = await checkAutoApprovalEligibility(db, userId, newMembership);
+    expect(result).toBe(true);
+  });
+
+  it("auto-approves non-student membership regardless of email", async () => {
+    const { db } = testDb;
+    const userId = crypto.randomUUID();
+    const typeId = `type-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createMembershipType(db, typeId);
+    await createUser(db, { id: userId, email: `${userId}@example.com` });
+
+    // No aalto email at all - should still auto-approve for non-student membership
+    await createMembership(db, {
+      id: `prev-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2024-01-01"),
+      endTime: new Date("2024-12-31"),
+      requiresStudentVerification: false,
+    });
+    await createMember(db, { userId, membershipId: `prev-${userId}`, status: "active" });
+
+    await createMembership(db, {
+      id: `new-${userId}`,
+      membershipTypeId: typeId,
+      startTime: new Date("2025-01-01"),
+      endTime: new Date("2025-12-31"),
+      requiresStudentVerification: false,
+    });
+
+    const newMembership = await getMembership(db, `new-${userId}`);
+
+    const result = await checkAutoApprovalEligibility(db, userId, newMembership);
+    expect(result).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
+import path from "node:path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      $lib: path.resolve("src/lib"),
+    },
+  },
   test: {
     include: ["tests/**/*.test.ts"],
     testTimeout: 60_000, // Testcontainers can be slow to start


### PR DESCRIPTION
## Summary
- Auto-approve membership renewals when the user had an approved membership of the same type in the immediately preceding period
- For student memberships, also requires a valid aalto.fi email
- Shows auto-approval status indicator on the purchase page per membership option
- Adds explanatory note on the admin memberships page

Supersedes #47 with a fresh implementation. Closes #33.