### PR TITLE
fix: add input validation pattern to OTP verification fields

### DIFF
--- a/src/routes/[locale=locale]/(app)/settings/emails/verify/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/settings/emails/verify/+page.svelte
@@ -4,6 +4,7 @@
   import { page } from "$app/stores";
   import { LL } from "$lib/i18n/i18n-svelte";
   import * as InputOTP from "$lib/components/ui/input-otp/index.js";
+  import { REGEXP_ONLY_DIGITS_AND_CHARS } from "bits-ui";
   import * as Card from "$lib/components/ui/card/index.js";
   import type { PageData } from "./$types";
   import { verifyCode, resendEmail, cancelVerification } from "./data.remote";
@@ -32,6 +33,8 @@
           <InputOTP.Root
             id="code"
             maxlength={8}
+            pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+            inputmode="text"
             name={verifyCode.fields.code.as("text").name}
             required
             class="justify-center capitalize"

--- a/src/routes/[locale=locale]/(public)/sign-in/email/+page.svelte
+++ b/src/routes/[locale=locale]/(public)/sign-in/email/+page.svelte
@@ -3,6 +3,7 @@
   import { Button } from "$lib/components/ui/button/index.js";
   import { LL } from "$lib/i18n/i18n-svelte";
   import * as InputOTP from "$lib/components/ui/input-otp/index.js";
+  import { REGEXP_ONLY_DIGITS_AND_CHARS } from "bits-ui";
   import type { PageData } from "./$types";
   import { verifyCode, resendEmail, changeEmail } from "./data.remote";
   import { verifyCodeSchema } from "./schema";
@@ -22,6 +23,8 @@
         <InputOTP.Root
           id="code"
           maxlength={8}
+          pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+          inputmode="text"
           name={verifyCode.fields.code.as("text").name}
           required
           class="capitalize"


### PR DESCRIPTION
## Summary
Enhanced OTP (One-Time Password) input fields across email verification flows by adding input validation patterns and input mode attributes to improve user experience and input handling.

## Key Changes
- Added `REGEXP_ONLY_DIGITS_AND_CHARS` pattern import from `bits-ui` to both email verification pages
- Applied pattern validation to `InputOTP.Root` components in:
  - Email verification page (`src/routes/[locale=locale]/(app)/settings/emails/verify/+page.svelte`)
  - Sign-in email verification page (`src/routes/[locale=locale]/(public)/sign-in/email/+page.svelte`)
- Set `inputmode="text"` attribute on both OTP input fields for better mobile keyboard handling

## Implementation Details
The changes ensure that OTP input fields only accept alphanumeric characters and provide appropriate input mode hints to mobile devices, improving the user experience during email verification flows. The pattern validation is consistent across both verification entry points in the application.

https://claude.ai/code/session_012qRrF75mxnPR7qWWSh1Ex6