### PR TITLE
fix: centralize date formatting with locale-FI helpers

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -84,6 +84,19 @@ export default ts.config(
           message:
             "Direct access to process.env is not allowed. Import from '$lib/server/env' instead for type-safe, validated environment variables.",
         },
+        {
+          selector: "CallExpression[callee.property.name='toLocaleDateString']",
+          message:
+            "Use formatDate() or formatDateRange() from '$lib/utils' instead to ensure consistent locale-FI formatting.",
+        },
+        {
+          selector: "CallExpression[callee.property.name='toLocaleString']",
+          message: "Use formatDateTime() from '$lib/utils' instead to ensure consistent locale-FI formatting.",
+        },
+        {
+          selector: "CallExpression[callee.property.name='toLocaleTimeString']",
+          message: "Use a date formatting helper from '$lib/utils' instead to ensure consistent locale-FI formatting.",
+        },
       ],
     },
   },

--- a/src/lib/components/membership-card.svelte
+++ b/src/lib/components/membership-card.svelte
@@ -4,6 +4,7 @@
   import { Badge } from "$lib/components/ui/badge/index.js";
   import { LL, locale } from "$lib/i18n/i18n-svelte";
   import { route } from "$lib/ROUTES";
+  import { formatDate } from "$lib/utils";
   import type { MemberStatus } from "$lib/shared/enums";
   import type { LocalizedString } from "$lib/server/db/schema";
   import { retryPayment } from "$lib/api/retry-payment.remote";
@@ -151,11 +152,11 @@
         <p class="text-2xl font-semibold">{getTypeName(currentMembership.membershipType)}</p>
         <p class="text-sm text-muted-foreground">
           <time datetime={currentMembership.startTime.toISOString()}>
-            {currentMembership.startTime.toLocaleDateString(`${$locale}-FI`)}
+            {formatDate(currentMembership.startTime, $locale)}
           </time>
           –
           <time datetime={currentMembership.endTime.toISOString()}>
-            {currentMembership.endTime.toLocaleDateString(`${$locale}-FI`)}
+            {formatDate(currentMembership.endTime, $locale)}
           </time>
         </p>
       </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -50,6 +50,24 @@ export function formatPrice(priceCents: number, currency: string, locale: string
   }).format(priceCents / 100);
 }
 
+/* eslint-disable no-restricted-syntax -- these are the canonical date formatting helpers that enforce locale-FI */
+
+/**
+ * Format a single date using Finnish locale conventions (e.g., "1.8.2024").
+ * Always uses locale-FI to ensure Finnish date formatting regardless of UI language.
+ */
+export function formatDate(date: Date, locale: string): string {
+  return date.toLocaleDateString(`${locale}-FI`);
+}
+
+/**
+ * Format a date with time using Finnish locale conventions.
+ * Always uses locale-FI to ensure Finnish date formatting regardless of UI language.
+ */
+export function formatDateTime(date: Date, locale: string): string {
+  return date.toLocaleString(`${locale}-FI`);
+}
+
 /**
  * Format a date range to a localized string (e.g., "1.8.2024 – 31.7.2025").
  */
@@ -68,6 +86,8 @@ export function formatShortDateRange(start: Date, end: Date, locale: string): st
   const endStr = end.toLocaleDateString(`${locale}-FI`, { day: "numeric", month: "numeric", year: "numeric" });
   return `${startStr} – ${endStr}`;
 }
+
+/* eslint-enable no-restricted-syntax */
 
 /**
  * Normalize an email address: remove all whitespace and lowercase.

--- a/src/routes/[locale=locale]/(app)/admin/members/create-member-form.svelte
+++ b/src/routes/[locale=locale]/(app)/admin/members/create-member-form.svelte
@@ -2,6 +2,7 @@
   import { invalidateAll } from "$app/navigation";
   import { toast } from "svelte-sonner";
   import { LL, locale } from "$lib/i18n/i18n-svelte";
+  import { formatDateRange as formatDateRangeUtil } from "$lib/utils";
   import { createMember } from "./data.remote";
   import { Input } from "$lib/components/ui/input";
   import { Textarea } from "$lib/components/ui/textarea";
@@ -48,10 +49,7 @@
   }
 
   function formatDateRange(m: AvailableMembership): string {
-    const dateLocale = $locale === "fi" ? "fi-FI" : "en-US";
-    const start = m.startTime.toLocaleDateString(dateLocale);
-    const end = m.endTime.toLocaleDateString(dateLocale);
-    return `${start} – ${end}`;
+    return formatDateRangeUtil(m.startTime, m.endTime, $locale);
   }
 
   // Group memberships by type for the select dropdown

--- a/src/routes/[locale=locale]/(app)/admin/members/import/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/admin/members/import/+page.svelte
@@ -48,7 +48,7 @@
   import { LL, locale } from "$lib/i18n/i18n-svelte";
   import * as v from "valibot";
   import AdminPageHeader from "$lib/components/admin-page-header.svelte";
-  import { normalizeEmail } from "$lib/utils";
+  import { normalizeEmail, formatDate } from "$lib/utils";
 
   import CircleCheck from "@lucide/svelte/icons/circle-check";
   import CircleAlert from "@lucide/svelte/icons/circle-alert";
@@ -701,7 +701,7 @@
                           <NativeSelect.OptGroup label={group.typeName}>
                             {#each group.memberships as m (m.id)}
                               <NativeSelect.Option value={m.id}>
-                                {m.startTime.toISOString().split("T")[0]} – {m.endTime.toISOString().split("T")[0]}
+                                {formatDate(m.startTime, $locale)} – {formatDate(m.endTime, $locale)}
                               </NativeSelect.Option>
                             {/each}
                           </NativeSelect.OptGroup>

--- a/src/routes/[locale=locale]/(app)/admin/members/members-table.svelte
+++ b/src/routes/[locale=locale]/(app)/admin/members/members-table.svelte
@@ -27,7 +27,7 @@
   import { page } from "$app/state";
   import { SvelteURLSearchParams } from "svelte/reactivity";
   import { LL, locale } from "$lib/i18n/i18n-svelte";
-  import { isNonEmpty } from "$lib/utils";
+  import { isNonEmpty, formatDate } from "$lib/utils";
   import {
     approveMember,
     rejectMember,
@@ -1059,8 +1059,11 @@
                             <div>
                               <dt class="text-muted-foreground">{$LL.admin.members.table.periodLabel()}</dt>
                               <dd>
-                                {membership.membershipStartTime?.toLocaleDateString() ?? "-"} - {membership.membershipEndTime?.toLocaleDateString() ??
-                                  "-"}
+                                {membership.membershipStartTime
+                                  ? formatDate(membership.membershipStartTime, $locale)
+                                  : "-"} - {membership.membershipEndTime
+                                  ? formatDate(membership.membershipEndTime, $locale)
+                                  : "-"}
                               </dd>
                             </div>
                             <div>
@@ -1079,7 +1082,7 @@
                             </div>
                             <div>
                               <dt class="text-muted-foreground">{$LL.admin.members.table.createdLabel()}</dt>
-                              <dd>{membership.createdAt.toLocaleDateString()}</dd>
+                              <dd>{formatDate(membership.createdAt, $locale)}</dd>
                             </div>
                             {#if membership.stripeSessionId}
                               <div>

--- a/src/routes/[locale=locale]/(app)/admin/users/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/admin/users/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { PageProps } from "./$types";
-  import { LL } from "$lib/i18n/i18n-svelte";
+  import { LL, locale } from "$lib/i18n/i18n-svelte";
+  import { formatDateTime } from "$lib/utils";
   import * as Table from "$lib/components/ui/table";
   import * as Select from "$lib/components/ui/select";
   import { Button } from "$lib/components/ui/button";
@@ -150,7 +151,7 @@
   // Format last active date
   function formatLastActive(lastActiveAt: Date | null) {
     if (!lastActiveAt) return $LL.admin.users.table.never();
-    return lastActiveAt.toLocaleString();
+    return formatDateTime(lastActiveAt, $locale);
   }
 
   // Check if there's only one full admin (use total admins with 'admin' role, not filtered)

--- a/src/routes/[locale=locale]/(app)/admin/users/data.remote.ts
+++ b/src/routes/[locale=locale]/(app)/admin/users/data.remote.ts
@@ -3,7 +3,7 @@ import { getRequestEvent, command } from "$app/server";
 import { db } from "$lib/server/db";
 import * as table from "$lib/server/db/schema";
 import { eq, sql } from "drizzle-orm";
-import { isNonEmpty } from "$lib/utils";
+import { isNonEmpty, formatDate } from "$lib/utils";
 import { updateUserRoleSchema, mergeUsersSchema } from "./schema";
 import { BLOCKING_MEMBER_STATUSES } from "$lib/shared/enums";
 import { auditUserAdminAction } from "$lib/server/audit";
@@ -134,8 +134,8 @@ export const mergeUsers = command(
             400,
             LL.admin.users.cannotMergeOverlapping({
               type: secondaryMember.membership.membershipTypeId,
-              startDate: new Date(secondaryMember.membership.startTime).toLocaleDateString(),
-              endDate: new Date(secondaryMember.membership.endTime).toLocaleDateString(),
+              startDate: formatDate(new Date(secondaryMember.membership.startTime), event.locals.locale),
+              endDate: formatDate(new Date(secondaryMember.membership.endTime), event.locals.locale),
             }),
           );
         }

--- a/src/routes/[locale=locale]/(app)/admin/verify-qr/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/admin/verify-qr/+page.svelte
@@ -6,7 +6,7 @@
   import CircleX from "@lucide/svelte/icons/circle-x";
   import X from "@lucide/svelte/icons/x";
   import { LL, locale } from "$lib/i18n/i18n-svelte";
-  import { cn, formatUserName } from "$lib/utils";
+  import { cn, formatUserName, formatDate as formatDateUtil } from "$lib/utils";
   import AdminPageHeader from "$lib/components/admin-page-header.svelte";
   import { Button } from "$lib/components/ui/button";
   import { Badge } from "$lib/components/ui/badge";
@@ -118,7 +118,7 @@
   }
 
   function formatDate(date: string | Date): string {
-    return new Date(date).toLocaleDateString(`${$locale}-FI`);
+    return formatDateUtil(new Date(date), $locale);
   }
 </script>
 

--- a/src/routes/[locale=locale]/(app)/membership/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/membership/+page.svelte
@@ -5,6 +5,7 @@
   import { Badge } from "$lib/components/ui/badge/index.js";
   import * as Item from "$lib/components/ui/item/index.js";
   import { LL, locale } from "$lib/i18n/i18n-svelte";
+  import { formatDateRange as formatDateRangeUtil } from "$lib/utils";
   import { route } from "$lib/ROUTES";
   import type { MemberStatus } from "$lib/shared/enums";
 
@@ -91,9 +92,7 @@
   }
 
   function formatDateRange(startTime: Date, endTime: Date) {
-    const start = new Date(startTime).toLocaleDateString(`${$locale}-FI`);
-    const end = new Date(endTime).toLocaleDateString(`${$locale}-FI`);
-    return `${start} – ${end}`;
+    return formatDateRangeUtil(new Date(startTime), new Date(endTime), $locale);
   }
 
   function getTypeName(membership: (typeof data.memberships)[number]) {

--- a/src/routes/[locale=locale]/(app)/new/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/new/+page.svelte
@@ -12,7 +12,7 @@
   import { payMembership } from "./data.remote";
   import { payMembershipSchema } from "./schema";
   import { getStripePriceMetadata } from "$lib/api/stripe.remote";
-  import { formatPrice } from "$lib/utils";
+  import { formatDate, formatPrice } from "$lib/utils";
   import { Textarea } from "$lib/components/ui/textarea";
   import { BLOCKING_MEMBER_STATUSES } from "$lib/shared/enums";
   import { PersistedState } from "runed";
@@ -161,8 +161,8 @@
                     {/snippet}
                   </svelte:boundary>
                   <span class="text-sm text-muted-foreground">
-                    {new Date(membership.startTime).toLocaleDateString(`${$locale}-FI`)}
-                    – {new Date(membership.endTime).toLocaleDateString(`${$locale}-FI`)}
+                    {formatDate(new Date(membership.startTime), $locale)}
+                    – {formatDate(new Date(membership.endTime), $locale)}
                   </span>
                   {#if membership.willAutoApprove}
                     <span class="text-xs text-green-600 dark:text-green-400">{$LL.membership.willAutoApprove()}</span>
@@ -224,7 +224,7 @@
                     {$LL.secondaryEmail.verifiedDomainEmail()}
                     {#if data.aaltoEmailExpiry}
                       ({$LL.secondaryEmail.expiresOn({
-                        date: new Date(data.aaltoEmailExpiry).toLocaleDateString(`${$locale}-FI`),
+                        date: formatDate(new Date(data.aaltoEmailExpiry), $locale),
                       })})
                     {/if}
                   </Alert.Description>

--- a/src/routes/[locale=locale]/(app)/settings/emails/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/settings/emails/+page.svelte
@@ -2,6 +2,7 @@
   import { invalidateAll } from "$app/navigation";
   import { page } from "$app/stores";
   import { LL, locale } from "$lib/i18n/i18n-svelte";
+  import { formatDate as formatDateUtil } from "$lib/utils";
   import { route } from "$lib/ROUTES";
   import { Button } from "$lib/components/ui/button/index.js";
   import * as Item from "$lib/components/ui/item/index.js";
@@ -36,7 +37,7 @@
 
   function formatDate(date: Date | null): string {
     if (!date) return "";
-    return new Date(date).toLocaleDateString(`${$locale}-FI`);
+    return formatDateUtil(new Date(date), $locale);
   }
 </script>
 

--- a/src/routes/[locale=locale]/(app)/settings/passkeys/+page.svelte
+++ b/src/routes/[locale=locale]/(app)/settings/passkeys/+page.svelte
@@ -17,6 +17,7 @@
 
   import { invalidateAll } from "$app/navigation";
   import { LL, locale } from "$lib/i18n/i18n-svelte";
+  import { formatDate as formatDateUtil } from "$lib/utils";
   import * as Empty from "$lib/components/ui/empty/index.js";
   import { Input } from "$lib/components/ui/input/index.js";
   import { Label } from "$lib/components/ui/label/index.js";
@@ -105,7 +106,7 @@
   function formatDate(date: Date | string | null): string {
     if (!date) return $LL.auth.passkey.never();
     const dateObj = typeof date === "string" ? new Date(date) : date;
-    return dateObj.toLocaleDateString(`${$locale}-FI`);
+    return formatDateUtil(dateObj, $locale);
   }
 </script>
 


### PR DESCRIPTION
## Summary
- Added `formatDate()` and `formatDateTime()` helpers to `$lib/utils` that always use `locale-FI` formatting
- Refactored all 13 files with date formatting to use the centralized helpers instead of direct `toLocaleDateString()`/`toLocaleString()` calls
- Fixed several bugs: missing locale in `members-table.svelte` and `admin/users` (caused US-style mm/dd/yyyy), wrong `en-US` locale in `create-member-form.svelte`
- Added ESLint `no-restricted-syntax` rules to forbid direct `toLocaleDateString`, `toLocaleString`, and `toLocaleTimeString` calls with messages pointing to the utils helpers

## Test plan
- [x] Verify dates display in Finnish format (d.m.yyyy) on the membership page, admin members table, and admin users page
- [x] Switch locale to English and verify dates still use Finnish regional conventions (en-FI)
- [x] Run `pnpm lint` to confirm ESLint rule catches any new direct date formatting calls
- [x] Run `pnpm check` to confirm no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)