### PR TITLE
RFC: Redesign membership model for indefinite memberships

### DIFF
--- a/docs/superpowers/specs/2026-04-03-membership-model-redesign-implementation.md
+++ b/docs/superpowers/specs/2026-04-03-membership-model-redesign-implementation.md
@@ -27,6 +27,14 @@ These rules are the correctness boundary for the implementation:
 11. A paid application or type change cannot be approved until its target
     obligation is settled. A direct admin activation is the separate,
     explicitly waived exception.
+12. Every purchasable membership type has exactly one valid application target;
+    there is no intentional closed-applications state.
+13. A new applicant owes the selected application fee period, not an earlier
+    period. Board approval activates membership immediately regardless of that
+    fee period's display dates.
+14. Ending membership cancels every unsettled obligation. Rejoining never
+    revives an old debt.
+15. Published fee-period dates and deadlines are immutable.
 
 Membership decisions lock the stable member row and append the event plus
 snapshot update in one transaction. Payment state changes and non-payment
@@ -41,15 +49,16 @@ use the project's snake-case convention.
 
 ### `membershipType`
 
-| Column                      | Type                    | Notes                                                 |
-| --------------------------- | ----------------------- | ----------------------------------------------------- |
-| id                          | TEXT PK                 | Stable identifier, for example `varsinainen-jasen`    |
-| name                        | JSONB (LocalizedString) | Display name                                          |
-| description                 | JSONB (LocalizedString) | Optional description                                  |
-| purchasable                 | BOOLEAN                 | Users may select this type themselves                 |
-| requiresPayment             | BOOLEAN                 | Members of this type normally receive annual fee dues |
-| requiresStudentVerification | BOOLEAN                 | Requires the configured student identity verification |
-| createdAt, updatedAt        | TIMESTAMPTZ             | Standard timestamps                                   |
+| Column                         | Type                           | Notes                                                        |
+| ------------------------------ | ------------------------------ | ------------------------------------------------------------ |
+| id                             | TEXT PK                        | Stable identifier, for example `varsinainen-jasen`           |
+| name                           | JSONB (LocalizedString)        | Display name                                                 |
+| description                    | JSONB (LocalizedString)        | Optional description                                         |
+| purchasable                    | BOOLEAN                        | Users may select this type themselves                        |
+| requiresPayment                | BOOLEAN                        | Members of this type normally receive annual fee dues        |
+| requiresStudentVerification    | BOOLEAN                        | Requires the configured student identity verification        |
+| legacyInferenceThroughPeriodId | TEXT FK -> membershipFeePeriod | Last fully billed legacy period; nullable until finalization |
+| createdAt, updatedAt           | TIMESTAMPTZ                    | Standard timestamps                                          |
 
 `purchasable` and `requiresPayment` are independent. For example, an honorary
 type may be neither purchasable nor payable. A type may also be free for a
@@ -75,17 +84,24 @@ application target, not the duration of legal membership.
 | acceptsApplications  | BOOLEAN                      | This is the user-facing target for new applications |
 | createdAt, updatedAt | TIMESTAMPTZ                  | Standard timestamps                                 |
 | UNIQUE               | (membershipTypeId,startDate) | One period per type and start date                  |
-| PARTIAL UNIQUE       | membershipTypeId             | At most one application target per type             |
+| PARTIAL UNIQUE       | membershipTypeId             | `WHERE acceptsApplications`; at most one target     |
 
 A period starts as a draft. Publishing it atomically creates obligations for
 applicable active members. Publishing never creates Stripe sessions or sends
-messages.
+messages. `endDate` must not precede `startDate`, and
+`nonPaymentActionAt` must follow `dueDate`; each association chooses the actual
+grace period required by its rules before publication.
 
-After publication, membership type, coverage dates, amount, and currency are
-locked. Admins may extend `dueDate` or `nonPaymentActionAt`, never move them
-earlier, and each change is audited. `acceptsApplications` may be moved between
-published periods with explicit confirmation. This supports opening an upcoming
-period early without deriving behavior from the calendar.
+After publication, membership type, every date, amount, and currency are locked.
+Post-publication deadline changes are not supported in this release.
+
+`acceptsApplications` moves atomically between published periods with explicit
+confirmation. It cannot simply be cleared. A type cannot become `purchasable`
+until a published, correctly priced target exists. A target may be current or
+upcoming, but it is invalid after its `endDate`; the application flow never
+falls back to an expired period. These application-level rules strengthen the
+partial index from "at most one" to the required "exactly one" across the type
+and period tables.
 
 New periods are pre-filled by shifting the previous period's dates. There is no
 global calendar-settings feature in this scope.
@@ -101,19 +117,21 @@ global calendar-settings feature in this scope.
 | membershipTypeId           | TEXT FK -> membershipType   | Most recently board-approved type; null if never approved              |
 | pendingMembershipTypeId    | TEXT FK -> membershipType   | Type currently requested; otherwise null                               |
 | currentMembershipStartedAt | TIMESTAMPTZ                 | Start of the current or most recently ended continuous membership      |
+| currentMembershipEndedAt   | TIMESTAMPTZ                 | End of the most recently ended interval; null while active             |
 | applicationMotive          | TEXT                        | Latest application motive; never reused as an end reason               |
 | createdAt, updatedAt       | TIMESTAMPTZ                 | Standard timestamps                                                    |
 | CHECK                      | userId XOR organizationName | Exactly one identity form                                              |
-| PARTIAL UNIQUE             | userId                      | One stable member per individual user                                  |
+| UNIQUE                     | userId                      | One stable member per user; PostgreSQL permits multiple nulls          |
 
 The approved type remains on an ended member for display. A paid applicant is
 not assigned the requested type before approval. During an active member's type
 change, `membershipTypeId` remains the old type and
 `pendingMembershipTypeId` contains the requested type.
 
-`currentMembershipStartedAt` means the latest continuous membership, not the
-first membership ever. Rejoining updates it on approval. The first join and all
-earlier intervals are retained in `membershipEvent`.
+`currentMembershipStartedAt` and `currentMembershipEndedAt` are the list-query
+snapshot of the latest interval, not the complete history. Rejoining replaces
+the start and clears the end on approval. The first join and every earlier
+interval remain in `membershipEvent`.
 
 ### `membershipEvent`
 
@@ -161,16 +179,17 @@ events may be collapsed for members and remain expandable for admins.
 An obligation exists only when a fee has actually been issued to a member. It
 is not backfilled for historical imports.
 
-| Column                | Type                             | Notes                                             |
-| --------------------- | -------------------------------- | ------------------------------------------------- |
-| id                    | TEXT PK                          |                                                   |
-| memberId              | TEXT FK -> member                |                                                   |
-| membershipFeePeriodId | TEXT FK -> membershipFeePeriod   |                                                   |
-| kind                  | ENUM                             | `renewal`, `application`, or `type_change`        |
-| disposition           | ENUM                             | `required`, `waived`, or `cancelled`              |
-| dispositionReason     | TEXT                             | Required for waiver; optional for cancellation    |
-| createdAt, updatedAt  | TIMESTAMPTZ                      | Standard timestamps                               |
-| UNIQUE                | (memberId,membershipFeePeriodId) | At most one issued fee for this member and period |
+| Column                | Type                                | Notes                                             |
+| --------------------- | ----------------------------------- | ------------------------------------------------- |
+| id                    | TEXT PK                             |                                                   |
+| memberId              | TEXT FK -> member                   |                                                   |
+| membershipFeePeriodId | TEXT FK -> membershipFeePeriod      |                                                   |
+| kind                  | ENUM                                | `renewal`, `application`, or `type_change`        |
+| disposition           | ENUM                                | `required`, `waived`, or `cancelled`              |
+| dispositionReason     | TEXT                                | Required for waiver; optional for cancellation    |
+| createdAt, updatedAt  | TIMESTAMPTZ                         | Standard timestamps                               |
+| UNIQUE                | (memberId,membershipFeePeriodId)    | At most one issued fee for this member and period |
+| UNIQUE                | (id,memberId,membershipFeePeriodId) | Composite payment FK target                       |
 
 Paid/unpaid is derived from payments and is not duplicated on the obligation.
 The three useful views are therefore:
@@ -184,6 +203,11 @@ obligation for every currently active member of that approved type. The unique
 constraint makes publication idempotent. Free types and zero-fee periods create
 no obligations. A non-zero period cannot be published for a type whose
 `requiresPayment` is false.
+
+An obligation may change from `required` to `cancelled`, or be restored to
+`required` after a rejected pending type change. Every disposition change is
+audited. Cancelling retains the obligation and payment history; it means the fee
+is no longer collectible.
 
 An admin who directly activates a member of a paid type either records a full
 manual payment or explicitly waives the applicable obligation with a reason.
@@ -218,13 +242,15 @@ necessary for Stripe webhook idempotency and delayed payment outcomes.
 
 A composite foreign key from
 `payment(obligationId, memberId, membershipFeePeriodId)` to the same obligation
-columns prevents payments from being attached across members or types.
+columns prevents payments from being attached across members or types. It uses
+PostgreSQL `MATCH SIMPLE`, so historical rows with a null `obligationId` are
+exempt while their member and fee-period provenance remains recorded.
 
 Each retry creates a new payment row. Failed and expired attempts are retained,
 not deleted. Unique Stripe identifiers make webhook replay idempotent. A partial
-unique index permits at most one `pending` Stripe attempt per obligation; a new
-attempt requires the previous session to be confirmed unusable and marked
-failed or expired.
+unique index on `obligationId WHERE status = 'pending'` permits at most one
+pending Stripe attempt per obligation; a new attempt requires the previous
+session to be confirmed unusable and marked failed or expired.
 
 The ledger must allow more than one successful payment because two real charges
 can occur despite checkout safeguards. The obligation is settled when at least
@@ -244,7 +270,8 @@ period amount and currency, and manual payments must match them.
 
 1. The user selects a purchasable type, not a year.
 2. The system targets that type's single published
-   `acceptsApplications` fee period. Without one, applications are unavailable.
+   `acceptsApplications` fee period. It does not derive the target from today's
+   date. The checkout shows the exact period, dates, and price.
 3. The stable member is created or reused with the target in
    `pendingMembershipTypeId`.
 4. For a paid period, the system creates an `application` obligation and a
@@ -254,7 +281,15 @@ period amount and currency, and manual payments must match them.
    `application_submitted`.
 6. Board approval moves the pending type to `membershipTypeId`, sets
    `currentMembershipStartedAt`, changes status to `active`, and appends
-   `application_approved`.
+   `application_approved`. Approval takes effect immediately even if the paid
+   fee period starts later.
+
+The application obligation is the new member's first issued fee. Approval does
+not create an obligation for any earlier period. Fee-period dates describe the
+fee and never gate legal membership, QR validity, or other member rights.
+Approval does create any missing renewal obligation for an already-published
+later period of the approved type. The member-period unique key prevents a
+duplicate when the application itself already covers that upcoming period.
 
 Failed or abandoned checkout leaves the applicant in `awaiting_payment`.
 Returning creates a new attempt when the old Stripe session is no longer
@@ -273,11 +308,35 @@ member returns to `ended`, preserving their old approved type and history. A
 later reapplication to the same period reopens the existing obligation instead
 of inserting a duplicate.
 
+### Application availability
+
+Applications cannot be intentionally closed. Every `purchasable` type must have
+one valid target: a published, unexpired period with complete amount/currency
+configuration and, for a non-zero paid fee, a usable Stripe price. Enabling a
+type or moving its target is transactional, and removing the last target is
+rejected. There is no fallback to the calendar-current or an expired period.
+
+The admin UI shows a persistent warning starting 30 days before a target ends.
+A daily operational check sends one deduplicated board email for that warning
+and one if the type actually becomes unavailable. The incident clears when a
+valid successor is selected. Email delivery uses a persisted incident key so
+restarts or concurrent server instances cannot duplicate it. These board
+availability alerts do not automate member reminders or membership decisions.
+
 ### Renewal
 
 Publishing a fee period issues obligations to the active members of its type.
 Paying one changes only the obligation's derived settlement state. The member
 remains active before, during, and after payment and requires no approval.
+
+For a type with `requiresStudentVerification`, checkout requires verification
+that is valid at payment time. Missing or expired verification hard-blocks
+same-type payment and presents an explicit choice: re-verify, or request and pay
+for an eligible type change. Verification expiry never changes legal membership
+or silently changes the obligation. If the member takes neither path, the
+required obligation follows the ordinary reminder and board-controlled overdue
+workflow, with the missing-verification reason visible to admins. Expiry after a
+successful payment has no retroactive effect.
 
 The admin overdue preset is based on:
 
@@ -302,13 +361,16 @@ period. They are not a general mid-period operation.
 3. After payment, `pendingMembershipTypeId` is set and
    `type_change_requested` is appended. The old approved type and active status
    remain unchanged.
-4. While the request is pending, the old type's obligation for the same new
-   period is excluded from reminders.
+4. When the target payment succeeds, the old type's obligation for the same new
+   period changes to `cancelled` with reason `pending_type_change`. This removes
+   it from reminders, overdue views, and bulk ending rather than relying on each
+   consumer to add an exception.
 5. Approval changes the approved type, clears the pending type, appends
-   `type_changed`, and cancels the replaced old-type obligation. It does not
-   restart `currentMembershipStartedAt`.
+   `type_changed`, and changes the old obligation's reason to
+   `replaced_by_type_change`. It does not restart
+   `currentMembershipStartedAt`.
 6. Rejection retains the old type, clears the pending type, appends
-   `type_change_rejected`, restores the old obligation to reminder views, and
+   `type_change_rejected`, restores the old obligation to `required`, and
    cancels the target obligation. A successful target payment is flagged for
    manual refund.
 
@@ -328,16 +390,23 @@ non-payment action is a board-triggered bulk operation and is disabled before
 The bulk transaction:
 
 1. validates that every selected member is still active and still unpaid;
-2. updates each snapshot to `ended`;
+2. updates each snapshot to `ended` and sets `currentMembershipEndedAt`;
 3. appends one confirmed `deemed_resigned_nonpayment` event per member; and
-4. retains the unpaid obligation as historical evidence.
+4. cancels every unsettled obligation with reason `membership_ended`.
+
+Voluntary resignation and expulsion perform the same obligation cancellation.
+The rows remain as historical evidence, but cancelled fees are not collectible
+and never reappear after rejoining.
 
 Notices are sent after the transaction. Delivery success or failure is recorded
 against the action, failed notices can be retried, and delivery failure never
 undoes the board decision.
 
-Rejoining uses the same stable member and the full application flow. Approval
-sets a new `currentMembershipStartedAt`; older intervals remain in events.
+Rejoining uses the same stable member and the full application flow. It creates
+an application obligation or, for the same fee period, reopens the existing
+cancelled row so the member pays immediately. Approval sets a new
+`currentMembershipStartedAt`, clears `currentMembershipEndedAt`, and leaves
+older intervals in events.
 
 ### Overdue rights and QR verification
 
@@ -361,7 +430,8 @@ The application never initiates a Stripe refund in this scope.
 
 When a paid application or type change is rejected, it sets
 `refundRequiredAt`. An admin refunds it in the Stripe Dashboard and then uses
-“Verify refund”; the server fetches Stripe's state and stores
+"Verify refund" on that exact payment; the server fetches its PaymentIntent and
+stores
 `refundConfirmedAt` and `stripeRefundId`. A non-Stripe refund may be confirmed
 manually with a required reference. Only a full refund clears the requirement;
 partial refunds are outside this release.
@@ -369,6 +439,11 @@ partial refunds are outside this release.
 A duplicate successful payment enters the same queue with
 `refundReason = duplicate_payment`. Recording the extra charge never displaces
 the earlier payment that already settled the obligation.
+
+If an admin refunds a different charge in Stripe, verification leaves the
+flagged payment pending, checks sibling Stripe payments for the obligation,
+synchronizes the actual refund, and reports the mismatch. Any other successful,
+non-refunded payment continues to settle the obligation.
 
 A confirmed refund stops the payment from settling its obligation. It never
 automatically changes legal membership.
@@ -382,12 +457,13 @@ The first renewal cycle uses an admin-triggered workflow:
 3. Send a bulk reminder.
 4. Record the delivery result and last message.
 
-Schedulers, recurring reminders, and Stripe-generated invoices remain out of
-scope.
+Scheduled or recurring member reminders and Stripe-generated invoices remain
+out of scope. The separate application-availability check only alerts admins
+about configuration outages.
 
 ### Imported uncertainty and corrections
 
-Member-facing UI shows an “imported information may be inaccurate” notice,
+Member-facing UI shows an "imported information may be inaccurate" notice,
 including the association's contact details, only while the current snapshot
 depends on inferred legacy events. Inferred history retains a visible marker.
 
@@ -402,16 +478,20 @@ collapse corrected events; admin history can expand them.
 Each installation has a nullable `membershipDataLiveAt` timestamp.
 
 - **Import mode:** while it is null, admins may repeatedly import historical
-  data and rebuild inferred history.
-- **Finalize and go live:** the admin reviews a final preview and explicitly
-  establishes the live boundary.
+  payment evidence and preview inferred history. Imports do not commit inferred
+  membership transitions yet.
+- **Finalize and go live:** after all available imports, the admin selects the
+  last fully billed period for each type, reviews the resulting inference, and
+  explicitly establishes the live boundary.
 - **Live mode:** later imports may add history only for fee periods beginning
   before the boundary. Rows for periods beginning on or after it are rejected.
 
-Stripe checkout is unavailable in import mode. Publishing or opening the first
-live fee period prompts the admin to finalize imports and sets
-`membershipDataLiveAt` in the same transaction. The first Stripe action never
-silently changes the mode.
+Finalization atomically stores each type's
+`legacyInferenceThroughPeriodId`, commits the previewed inferred events, sets
+`membershipDataLiveAt`, and replays the current snapshots. The finalization UI
+cannot guess those cutoffs before all imports have run. Stripe checkout is
+unavailable in import mode. Publishing or opening the first live fee period
+prompts this finalization; the first Stripe action never silently changes mode.
 
 Historical rows imported after go-live cannot create inference at or after the
 boundary and cannot override confirmed events. This makes finalization a real
@@ -443,11 +523,12 @@ the inference `asOf` date. Tietokilta's production fallback is:
 - due: September 30; and
 - earliest non-payment action: December 1.
 
-The importer creates missing historical `membershipFeePeriod` rows for the
-expected sequence between the earliest imported period and `asOf`, including
-empty periods needed to recognize a gap. These historical periods remain
-unpublished and never create obligations. If the import cannot establish an
-expected period sequence, it preserves payments but reports that lifecycle
+For preview and finalized inference, the importer creates missing historical
+`membershipFeePeriod` rows only in the expected sequence between the earliest
+imported period and the selected last fully billed period. It never extends the
+sequence to the current date merely because time passed. The historical rows
+remain unpublished and never create obligations. If the import cannot establish
+an expected sequence, it preserves payments but reports that lifecycle
 inference is unavailable.
 
 Historical fee amount and currency may be null when the source data does not
@@ -496,24 +577,28 @@ available history.
 
 ### Inference algorithm
 
-After adding evidence, the importer recomputes only replaceable inferred events
-for affected members. It never deletes a member, confirmed event, payment,
-obligation, or live field in order to rebuild history.
+After finalization, an additive historical import recomputes only replaceable
+inferred events for affected members and only through that type's stored cutoff.
+Before finalization, the same algorithm powers a rollback-only preview. It never
+deletes a member, confirmed event, payment, obligation, or live field in order
+to rebuild history.
 
 For each affected member:
 
 1. Load all non-invalidated imported payments, relevant successful live
    payments, historical fee periods, and confirmed membership events.
 2. Remove the member's previous imported/migration events with
-   `certainty = inferred` before the live boundary, or all such events while
-   still in import mode.
+   `certainty = inferred` before the live boundary and within the relevant
+   type's stored cutoff. In import mode, do this only inside the preview
+   transaction.
 3. Sort evidence by exact period dates, independent of CSV and import order.
 4. The first legacy payment infers a membership start at the period start unless
    a confirmed event already establishes a different state.
 5. Consecutive paid periods add payments only. They are not membership renewal
    events.
-6. For a missing expected period, infer `legacy_resignation_inferred` at that
-   period's `nonPaymentActionAt` only when `asOf` has reached the date.
+6. For a missing expected period no later than the selected last fully billed
+   period, infer `legacy_resignation_inferred` at that period's
+   `nonPaymentActionAt` only when `asOf` has reached the date.
 7. A later payment after an inferred end adds `legacy_rejoin_inferred` at the
    later period's start.
 8. A sequential change to a different type adds an inferred type-change event
@@ -525,10 +610,10 @@ For each affected member:
 
 The December 1 Tietokilta fallback is explicitly an inference based on recent
 bulk-resignation practice. It does not claim that the board made a recorded
-decision on that date. A member whose latest missing period has a future action
-date remains inferred active. Once the live boundary is established, merely
-passing a deadline never creates a new event; only a real board action can end
-membership for a live obligation.
+decision on that date. No absence after the selected fully billed cutoff proves
+anything, and a gap whose action date is still in the future creates no end.
+Once the live boundary is established, merely passing a deadline never creates
+a new event; only a real board action can end membership for a live obligation.
 
 If a later additive import fills a historical gap, the inferred end and rejoin
 events disappear on rebuild. Member UI may collapse the correction, while admin
@@ -561,7 +646,7 @@ All import sequences below converge after the inferred events are rebuilt:
 | 2023, 2024, 2025 in any order              | One stable member, three payments, one continuous membership              |
 | 2020, 2021, 2024, 2025                     | Four payments, inferred end at the 2022 action date, rejoin in 2024       |
 | Previous row set, then 2022 and 2023       | Six payments; the inferred end and rejoin disappear                       |
-| 2025 Stripe payment, then 2020–2025 import | One stable member; Stripe evidence is retained and duplicate 2025 skipped |
+| 2025 Stripe payment, then 2020-2025 import | One stable member; Stripe evidence is retained and duplicate 2025 skipped |
 | Confirmed resignation, then older import   | Payment history is added; confirmed current state remains unchanged       |
 
 ## Production migration
@@ -584,7 +669,8 @@ Migration must not turn every old row into a paid payment. In particular,
 
 The migration uses this evidence in descending authority:
 
-1. Existing audit actions create confirmed board/admin events.
+1. A successfully mapped audit action may create a confirmed board/admin event;
+   audit absence proves nothing because current writes are best-effort.
 2. `awaiting_approval` proves that the application payment completed.
 3. For a payable type, `active` or an old status representing previously active
    membership is evidence of a completed purchase. A Stripe session makes its
@@ -602,6 +688,29 @@ The migration uses this evidence in descending authority:
 The migration never copies `member.createdAt` into `payment.paidAt`. Unknown is
 represented as null.
 
+### Legacy audit mapping
+
+`audit_log.targetId` is plain text, and bulk actions store comma-separated old
+member IDs as well as `metadata.memberIds`. The migration therefore builds an
+explicit old-period-member-to-stable-member map, rewrites both representations,
+and only then classifies the actions:
+
+| Existing action                                     | Migration meaning                                                                                                                |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `member.approve`, `member.bulk_approve`             | `application_approved` when inactive; `type_changed` for a clear active-member type change; same-type renewal adds no transition |
+| `member.auto_approve`                               | Renewal/payment evidence only; never board approval                                                                              |
+| `member.reject`, `member.bulk_reject`               | `application_rejected` for a pending join, or `type_change_rejected` for a pending change; ambiguous rows are rehearsal warnings |
+| `member.deem_resigned`, `member.bulk_deem_resigned` | Confirmed `deemed_resigned_nonpayment`                                                                                           |
+| `member.resign`, `member.bulk_resign`               | Confirmed `resigned_voluntarily`                                                                                                 |
+| `member.create`                                     | Classified from its initial status and payment/waiver evidence                                                                   |
+| `member.bulk_import`                                | Import provenance only; never a confirmed membership decision                                                                    |
+
+`member.reactivate` is a legacy escape hatch, not a new domain event. The
+rehearsal counts any individual or bulk reactivation rows and requires those
+rare rows to be classified manually as either a correction or a genuine
+rejoining approval. If there are none, no mapping exists. Stale action names in
+the TypeScript union do not by themselves create migration evidence.
+
 ### Transaction steps
 
 Within one migration transaction:
@@ -614,17 +723,20 @@ Within one migration transaction:
 3. Backfill Tietokilta historical due and inference dates using September 30 and
    December 1. Mark them as migration assumptions.
 4. Collapse old per-period rows into one stable member per user or organization.
-   Preserve a deterministic existing identifier and rewire every referencing
-   row before removing duplicates.
-5. Create payments and confirmed/inferred membership events according to the
+   Preserve a deterministic existing identifier and build the complete old-to-
+   stable ID map.
+5. Rewire real foreign keys, then explicitly split and remap audit
+   `targetId`/`metadata.memberIds` values before removing duplicate rows.
+6. Create payments and confirmed/inferred membership events according to the
    evidence rules above. Do not create historical obligations.
-6. Replay events to materialize `status`, approved/pending type, and
-   `currentMembershipStartedAt`.
-7. Preserve all existing organization members without attempting CSV-style
+7. Replay events to materialize `status`, approved/pending type,
+   `currentMembershipStartedAt`, and `currentMembershipEndedAt`.
+8. Preserve all existing organization members without attempting CSV-style
    inference.
-8. Validate database invariants and expected classifications.
-9. Set `membershipDataLiveAt` because this installation contained live legacy
-   data, then remove obsolete period-shaped columns and rows.
+9. Validate database invariants and expected classifications.
+10. Store the rehearsed last-fully-billed cutoff for each legacy type and set
+    `membershipDataLiveAt` because this installation contained live legacy
+    data, then remove obsolete period-shaped columns and rows.
 
 Any invariant failure aborts the whole transaction. Delayed Stripe webhooks
 remain safe because old session identifiers are retained on payment attempts
@@ -641,7 +753,9 @@ Its report includes:
 - before/after counts by old and new status;
 - classification counts for Stripe, imported, pending, and ambiguous payments;
 - stable-member collapses and reference rewrites;
+- remapped audit targets, action classifications, and any legacy reactivations;
 - inferred starts, ends, rejoins, and type changes;
+- the selected last fully billed period for each type;
 - ambiguous rejected rows and overlapping types;
 - timezone/date conversions;
 - current snapshots that still depend on inference;
@@ -661,19 +775,19 @@ boundaries. Dates must use a fixed clock and the Europe/Helsinki timezone.
 
 ### Member identity and history
 
-| Scenario                                      | Expected result                                                               |
-| --------------------------------------------- | ----------------------------------------------------------------------------- |
-| First application is approved                 | One stable member becomes active; approved type and start time are set        |
-| Active member changes type                    | Same member ID; continuous start remains; a confirmed type event is appended  |
-| Ended member rejoins                          | Same member ID; a new continuous start is set; old interval remains in events |
-| Reapplication by an ended member is rejected  | Snapshot returns to ended; rejection remains in events                        |
-| Never-approved application is rejected        | Status becomes rejected; approved type remains null                           |
-| Voluntary resignation                         | Status becomes ended with a confirmed voluntary event                         |
-| Expulsion                                     | Status becomes ended with a confirmed expulsion event                         |
-| Admin corrects a wrong ending action          | Correction event references the old event; snapshot is restored               |
-| Member has imported and confirmed history     | Confirmed state wins; inferred events stay visibly labelled                   |
-| Same user is inserted twice concurrently      | The stable-member uniqueness constraint prevents a duplicate                  |
-| Two approved types are attempted concurrently | The transaction/constraint permits only one approved current type             |
+| Scenario                                     | Expected result                                                              |
+| -------------------------------------------- | ---------------------------------------------------------------------------- |
+| First application is approved                | One stable member becomes active; approved type and start time are set       |
+| Active member changes type                   | Same member ID; continuous start remains; a confirmed type event is appended |
+| Ended member rejoins                         | Same member ID; applicable application fee is paid; a new interval starts    |
+| Reapplication by an ended member is rejected | Snapshot returns to ended; rejection remains in events                       |
+| Never-approved application is rejected       | Status becomes rejected; approved type remains null                          |
+| Voluntary resignation                        | Status becomes ended with a confirmed voluntary event                        |
+| Expulsion                                    | Status becomes ended with a confirmed expulsion event                        |
+| Admin corrects a wrong ending action         | Correction event references the old event; snapshot is restored              |
+| Member has imported and confirmed history    | Confirmed state wins; inferred events stay visibly labelled                  |
+| Same user is inserted twice concurrently     | The stable-member uniqueness constraint prevents a duplicate                 |
+| Two type approvals race on the same member   | Member-row locking serializes them; the later transaction revalidates state  |
 
 ### Applications and payment attempts
 
@@ -692,66 +806,96 @@ boundaries. Dates must use a fixed clock and the Europe/Helsinki timezone.
 | User returns while a session is still reusable     | Existing pending session may be resumed                                        |
 | Free purchasable type is submitted                 | No payment or obligation; applicant proceeds to board approval                 |
 | Board approves a paid application                  | Member becomes active; payment is unchanged                                    |
+| Upcoming period is the application target          | Checkout identifies it; no fee is created for the earlier period               |
+| Upcoming-period applicant is approved early        | Membership starts immediately; fee-period dates do not gate membership         |
+| Spring applicant pays the current application fee  | Approval also issues any already-published later renewal; both fees remain due |
 | Board tries to approve before required payment     | Approval is rejected                                                           |
 | Board rejects a paid application                   | Member is rejected/returned to ended; obligation is cancelled; refund required |
 | Admin verifies the Stripe refund                   | Refund identifiers are stored and payment no longer settles the obligation     |
+| Admin refunded a different Stripe charge           | Flagged refund remains pending; the actual refund is synchronized and warned   |
 | Admin confirms a non-Stripe refund                 | A manual reference is required                                                 |
 | Applicant pays after the general due date          | Approval may proceed; they never appear as an existing overdue member          |
 | Payment member/period mismatches its obligation    | Composite foreign key rejects the write                                        |
 
+### Application availability
+
+| Scenario                                  | Expected result                                                                |
+| ----------------------------------------- | ------------------------------------------------------------------------------ |
+| Purchasable type has no valid target      | Configuration change is rejected, or an existing outage is shown prominently   |
+| Admin tries to clear the only target      | Operation is rejected; replacement must be selected atomically                 |
+| Target ends within 30 days                | Persistent admin warning and one deduplicated board email                      |
+| Target expires without replacement        | No expired fallback; one outage email; public flow shows configuration failure |
+| Upcoming target is selected early         | Applications remain available and payments bind to that upcoming period        |
+| Successor is selected after an incident   | Alert clears and applications recover immediately                              |
+| Daily check or server instance runs twice | Persisted incident key prevents duplicate email                                |
+
 ### Fee periods and obligations
 
-| Scenario                                               | Expected result                                                    |
-| ------------------------------------------------------ | ------------------------------------------------------------------ |
-| Draft period is saved                                  | No obligation is created                                           |
-| Non-zero payable period is published                   | One renewal obligation per applicable active member                |
-| Publication is retried                                 | No duplicate obligations                                           |
-| Free membership type period is published               | No obligations                                                     |
-| Free type has a non-zero draft amount                  | Publication is rejected                                            |
-| Payable type has a zero-fee period                     | No obligations                                                     |
-| New active member is added after publication           | Admin records a full manual payment or a reasoned waiver           |
-| Admin directly activates a paid member without payment | Waived obligation is required; no fake payment                     |
-| Active member pays the renewal                         | Obligation settles; membership status and start time do not change |
-| Payment from the previous period exists                | New period's obligation remains unsettled                          |
-| Member has no issued obligation                        | They do not appear in due/overdue views                            |
-| Required obligation is refunded                        | It becomes unsettled; legal membership remains unchanged           |
-| Admin extends a deadline                               | Later date is saved and audited; all affected obligations use it   |
-| Admin tries to shorten a published deadline            | Operation is rejected                                              |
-| Admin edits published type, dates, amount, or currency | Operation is rejected                                              |
-| Partial or incorrectly sized manual payment is entered | Operation is rejected                                              |
+| Scenario                                               | Expected result                                                      |
+| ------------------------------------------------------ | -------------------------------------------------------------------- |
+| Draft period is saved                                  | No obligation is created                                             |
+| Non-zero payable period is published                   | One renewal obligation per applicable active member                  |
+| Publication is retried                                 | No duplicate obligations                                             |
+| Free membership type period is published               | No obligations                                                       |
+| Free type has a non-zero draft amount                  | Publication is rejected                                              |
+| Payable type has a zero-fee period                     | No obligations                                                       |
+| New applicant joins after publication                  | Application covers its target; published later periods are caught up |
+| Admin directly activates a paid member without payment | Waived obligation is required; no fake payment                       |
+| Active member pays the renewal                         | Obligation settles; membership status and start time do not change   |
+| Payment from the previous period exists                | New period's obligation remains unsettled                            |
+| Member has no issued obligation                        | They do not appear in due/overdue views                              |
+| Required obligation is refunded                        | It becomes unsettled; legal membership remains unchanged             |
+| Admin edits any published date or deadline             | Operation is rejected                                                |
+| Admin edits published type, amount, or currency        | Operation is rejected                                                |
+| Partial or incorrectly sized manual payment is entered | Operation is rejected                                                |
+
+### Student verification
+
+| Scenario                                      | Expected result                                                                      |
+| --------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Verification is valid at renewal checkout     | Same-type payment proceeds normally                                                  |
+| Verification is missing or expired            | Same-type checkout is blocked; re-verification and type-change choices are shown     |
+| Member re-verifies                            | The existing obligation can be paid; no duplicate is created                         |
+| Member requests an eligible paid type change  | Target payment proceeds to board approval; old obligation is cancelled while pending |
+| Verification expires after successful payment | Payment and legal membership remain unchanged                                        |
+| Member takes no action before the due date    | Membership remains active; admins see overdue plus missing-verification context      |
+| Board confirms loss of eligibility            | Board may approve the appropriate type change; expiry alone never performs it        |
 
 ### Overdue, reminders, and ending membership
 
-| Scenario                                             | Expected result                                                               |
-| ---------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Required obligation is unpaid before due date        | Fee state is not due; member is active                                        |
-| Required obligation is unpaid after due date         | Fee state is overdue; member is still active                                  |
-| Honorary/free member                                 | Does not appear in the overdue preset                                         |
-| Obligation is waived or cancelled                    | Does not appear in the overdue preset                                         |
-| Successful payment exists                            | Does not appear in the overdue preset                                         |
-| Admin sends a reminder                               | Only reviewed eligible members are contacted; result is recorded              |
-| Scheduler time passes                                | No automatic reminder or status change occurs                                 |
-| Bulk ending is attempted before `nonPaymentActionAt` | Action is blocked                                                             |
-| Member pays between bulk preview and commit          | Member is not ended; admin sees that the row changed                          |
-| Eligible bulk action is committed                    | Member becomes ended and gets a confirmed non-payment event                   |
-| Notice delivery fails after the decision             | Ending remains committed; failed notice is visible and retryable              |
-| Ended member's old unpaid obligation is viewed       | It remains as historical unpaid evidence but not a current reminder recipient |
-| Overdue active member presents QR                    | Access remains valid; admin scan may also display “Overdue”                   |
+| Scenario                                             | Expected result                                                   |
+| ---------------------------------------------------- | ----------------------------------------------------------------- |
+| Required obligation is unpaid before due date        | Fee state is not due; member is active                            |
+| Required obligation is unpaid after due date         | Fee state is overdue; member is still active                      |
+| Honorary/free member                                 | Does not appear in the overdue preset                             |
+| Obligation is waived or cancelled                    | Does not appear in the overdue preset                             |
+| Successful payment exists                            | Does not appear in the overdue preset                             |
+| Admin sends a reminder                               | Only reviewed eligible members are contacted; result is recorded  |
+| Scheduler time passes                                | No automatic reminder or status change occurs                     |
+| Bulk ending is attempted before `nonPaymentActionAt` | Action is blocked                                                 |
+| Member pays between bulk preview and commit          | Member is not ended; admin sees that the row changed              |
+| Eligible bulk action is committed                    | Member becomes ended and gets a confirmed non-payment event       |
+| Notice delivery fails after the decision             | Ending remains committed; failed notice is visible and retryable  |
+| Membership is ended                                  | Every unsettled obligation is cancelled with the ending reason    |
+| Ended member's old unpaid obligation is viewed       | Historical row remains cancelled and is not collectible           |
+| Ended member rejoins                                 | Old fee stays cancelled; application fee must be paid immediately |
+| Overdue active member presents QR                    | Access remains valid; admin scan may also display "Overdue"       |
 
 ### Type changes during a new period
 
-| Scenario                                          | Expected result                                                               |
-| ------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Member selects their existing type                | Normal renewal; no board approval                                             |
-| Member selects a different eligible type          | Target obligation/payment starts; old type remains approved and active        |
-| Type-change checkout is abandoned                 | Old type and obligation remain unchanged; no pending board request            |
-| Paid type change awaits approval                  | Old obligation is suppressed from reminders; old legal type remains active    |
-| Board approves type change                        | Target type becomes approved; old obligation is cancelled; start is unchanged |
-| Board tries to approve unpaid type change         | Approval is rejected                                                          |
-| Board rejects paid type change                    | Old type/obligation remain; target obligation is cancelled; refund required   |
-| Member already paid the new period under old type | Self-service type change is unavailable; admin handles the exception          |
-| Member tries a mid-period self-service change     | Operation is unavailable                                                      |
-| Target type is free and purchasable               | Request skips checkout but still requires board approval                      |
+| Scenario                                           | Expected result                                                                 |
+| -------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Member selects their existing type                 | Normal renewal; no board approval                                               |
+| Member selects a different eligible type           | Target obligation/payment starts; old type remains approved and active          |
+| Type-change checkout is abandoned                  | Old type and obligation remain unchanged; no pending board request              |
+| Paid type change awaits approval                   | Old obligation is cancelled at source; old legal type remains active            |
+| Bulk ending runs while type change awaits approval | Cancelled old obligation excludes the member from the non-payment candidate set |
+| Board approves type change                         | Target type becomes approved; old obligation is cancelled; start is unchanged   |
+| Board tries to approve unpaid type change          | Approval is rejected                                                            |
+| Board rejects paid type change                     | Old obligation is restored; target is cancelled; refund required                |
+| Member already paid the new period under old type  | Self-service type change is unavailable; admin handles the exception            |
+| Member tries a mid-period self-service change      | Operation is unavailable                                                        |
+| Target type is free and purchasable                | Request skips checkout but still requires board approval                        |
 
 ### Import identity and idempotency
 
@@ -776,21 +920,23 @@ boundaries. Dates must use a fixed clock and the Europe/Helsinki timezone.
 
 ### Import inference and mixed sources
 
-| Scenario                                                  | Expected result                                                               |
-| --------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Gap action date is still in the future                    | Member remains inferred active                                                |
-| Missing period's December 1 action date has passed        | Inferred end is created with imported/migration provenance                    |
-| A later paid period follows the gap                       | Inferred rejoin is created on the later period start                          |
-| Gap is filled in a later import                           | Inferred end/rejoin disappear; payments and stable member remain              |
-| Sequential periods change membership type                 | Inferred type change; continuous start remains                                |
-| Mutually exclusive types overlap                          | Payments remain; no transition inferred; review warning                       |
-| Confirmed admin resignation differs from inferred history | Import adds payment history but confirmed current state wins                  |
-| Confirmed correction exists                               | Rebuild does not restore the corrected inference                              |
-| Import mode receives another historical file              | All affected pre-live inference is rebuilt                                    |
-| Go-live is finalized                                      | Boundary is stored; Stripe/live workflows become available                    |
-| Post-live import adds a pre-boundary period               | Historical evidence/inference may be added; confirmed state remains protected |
-| Post-live import contains a post-boundary period          | Row is rejected                                                               |
-| Fresh installation runs all Drizzle migrations            | It remains in import mode because no legacy members exist                     |
+| Scenario                                                  | Expected result                                                                |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Gap action date is still in the future                    | Member remains inferred active                                                 |
+| Missing period's December 1 action date has passed        | Inferred end is created with imported/migration provenance                     |
+| A later paid period follows the gap                       | Inferred rejoin is created on the later period start                           |
+| Gap is filled in a later import                           | Inferred end/rejoin disappear; payments and stable member remain               |
+| Sequential periods change membership type                 | Inferred type change; continuous start remains                                 |
+| Mutually exclusive types overlap                          | Payments remain; no transition inferred; review warning                        |
+| Confirmed admin resignation differs from inferred history | Import adds payment history but confirmed current state wins                   |
+| Confirmed correction exists                               | Rebuild does not restore the corrected inference                               |
+| Import mode receives another historical file              | Evidence is added; inference preview changes but no transition is committed    |
+| Go-live is finalized                                      | Per-type fully billed cutoffs and boundary are stored; preview is committed    |
+| Onboarding in December has data only through last year    | Admin selects that last billed period; no missing-current-year end is inferred |
+| Missing period is after the selected cutoff               | No resignation is inferred                                                     |
+| Post-live import adds a pre-boundary period               | Historical evidence/inference may be added; confirmed state remains protected  |
+| Post-live import contains a post-boundary period          | Row is rejected                                                                |
+| Fresh installation runs all Drizzle migrations            | It remains in import mode because no legacy members exist                      |
 
 ### Production migration
 
@@ -803,6 +949,10 @@ boundaries. Dates must use a fixed clock and the Europe/Helsinki timezone.
 | Free active member                               | Membership preserved without a fake payment                                |
 | `rejected` with no proof of completed payment    | Rejected state preserved; no success invented; rehearsal warning           |
 | Audited board decision                           | Confirmed event with separate effective and recorded timestamps            |
+| Bulk audit target contains comma-separated IDs   | Every old ID and metadata entry is remapped to the stable member           |
+| `member.auto_approve` audit exists               | Renewal evidence only; no application approval event is fabricated         |
+| No legacy reactivation audit exists              | No reactivation mapping or event is created                                |
+| Legacy reactivation audit exists                 | Rehearsal requires explicit correction-or-rejoin classification            |
 | Old local-midnight period timestamp              | Correct Helsinki calendar date, without UTC off-by-one                     |
 | Several period rows for one user                 | One stable member; dependencies are rewired                                |
 | Existing organization member                     | Preserved for manual management                                            |
@@ -830,10 +980,10 @@ Keep code review small even though production has one cutover:
 1. Add schema definitions, constraints, event replay, and pure domain tests.
 2. Add the production migration, local rehearsal helper, and migration fixtures.
 3. Replace legacy CSV import with preview, additive evidence, and inference.
-4. Implement fee-period publication, obligations, renewal checkout, and Stripe
-   webhook idempotency.
-5. Migrate application, reapplication, paid type-change, and manual refund
-   workflows.
+4. Implement fee-period publication, application availability, obligations,
+   renewal checkout, and Stripe webhook idempotency.
+5. Migrate application, reapplication, student verification, paid type-change,
+   and manual refund workflows.
 6. Add overdue/reminder views, history/provenance UI, QR fee display, and the
    bulk non-payment action.
 
@@ -847,10 +997,11 @@ Before renewals open:
 
 1. Finish schema/domain tests and the importer/migration rehearsal.
 2. Run the exact migration against a recent production snapshot early enough to
-   fix classifications, not only immediately before deployment.
+   fix classifications well before deployment.
 3. Reconcile rehearsal counts and explicitly classify every warning category.
-4. Complete period publication, obligation creation, renewals, new
-   applications, and new-period type changes.
+4. Complete period publication, availability alerts, obligation creation,
+   renewals, new applications, student verification, and new-period type
+   changes.
 5. Verify that the overdue preset excludes free, waived, newly joined, and paid
    members.
 6. Complete the member-facing imported-data warning and preserve legally active
@@ -867,8 +1018,9 @@ August payments if their data invariants and tests already exist.
 2. Take and verify a restorable production snapshot.
 3. Run the already-rehearsed transactional Drizzle migration.
 4. Run invariant queries and compare counts with the rehearsal report.
-5. Smoke-test admin lists, one member history, application targeting, Stripe
-   checkout in test mode, renewal eligibility, and QR verification.
+5. Smoke-test admin lists, one member history, application targeting and outage
+   warning, Stripe checkout in test mode, renewal eligibility, and QR
+   verification.
 6. Re-enable writes and monitor Stripe webhooks, payment attempts, and errors.
 
 If migration or validation fails, the transaction rolls back and the old
@@ -885,5 +1037,7 @@ Do not open renewals until:
 - two independent rehearsal runs converge;
 - Stripe webhook replay and delayed-webhook tests pass;
 - publication retry creates no duplicate obligations;
+- every purchasable type has one valid application target and alert deduplication
+  passes;
 - the board can obtain the exact active-and-unpaid list; and
 - backup restoration has been exercised or otherwise verified.

--- a/docs/superpowers/specs/2026-04-03-membership-model-redesign-implementation.md
+++ b/docs/superpowers/specs/2026-04-03-membership-model-redesign-implementation.md
@@ -1,0 +1,889 @@
+# Membership Model Redesign: Implementation Reference
+
+This document contains the proposed schema, algorithms, scenario matrix, and
+rollout details for the
+[membership model RFC](./2026-04-03-membership-model-redesign.md). The RFC is
+the review document and source of product decisions.
+
+## Invariants
+
+These rules are the correctness boundary for the implementation:
+
+1. One person or organization has one stable `member` aggregate.
+2. A member has at most one approved membership type at a time.
+3. Paying a renewal never approves, renews, or ends legal membership.
+4. No failed, expired, or abandoned checkout rejects an application.
+5. Only a confirmed board/admin action changes an active membership to `ended`.
+6. Overdue members retain all membership rights until that action, including QR
+   verification and member-only access.
+7. Imported inference may be rebuilt. Confirmed events are immutable and may
+   only be corrected by a new event.
+8. A fee is due only when a `required` obligation exists. Lack of a payment row
+   alone does not create a debt.
+9. A required obligation is settled only by a successful, non-refunded,
+   non-invalidated payment for that obligation.
+10. Live Stripe/manual activity and confirmed membership events always take
+    precedence over imported inference.
+11. A paid application or type change cannot be approved until its target
+    obligation is settled. A direct admin activation is the separate,
+    explicitly waived exception.
+
+Membership decisions lock the stable member row and append the event plus
+snapshot update in one transaction. Payment state changes and non-payment
+actions lock the relevant obligation before deciding whether it is settled.
+Using the same member-then-obligation lock order prevents a payment/bulk-action
+race from ending a member who just paid.
+
+## Data model
+
+Names below use application-level camel case. Database migrations continue to
+use the project's snake-case convention.
+
+### `membershipType`
+
+| Column                      | Type                    | Notes                                                 |
+| --------------------------- | ----------------------- | ----------------------------------------------------- |
+| id                          | TEXT PK                 | Stable identifier, for example `varsinainen-jasen`    |
+| name                        | JSONB (LocalizedString) | Display name                                          |
+| description                 | JSONB (LocalizedString) | Optional description                                  |
+| purchasable                 | BOOLEAN                 | Users may select this type themselves                 |
+| requiresPayment             | BOOLEAN                 | Members of this type normally receive annual fee dues |
+| requiresStudentVerification | BOOLEAN                 | Requires the configured student identity verification |
+| createdAt, updatedAt        | TIMESTAMPTZ             | Standard timestamps                                   |
+
+`purchasable` and `requiresPayment` are independent. For example, an honorary
+type may be neither purchasable nor payable. A type may also be free for a
+particular period by publishing a zero-fee period.
+
+### `membershipFeePeriod`
+
+This replaces the misleading `membershipPeriod` name. It describes a fee and
+application target, not the duration of legal membership.
+
+| Column               | Type                         | Notes                                               |
+| -------------------- | ---------------------------- | --------------------------------------------------- |
+| id                   | TEXT PK                      |                                                     |
+| membershipTypeId     | TEXT FK -> membershipType    |                                                     |
+| startDate            | DATE                         | Coverage/display start                              |
+| endDate              | DATE                         | Coverage/display end                                |
+| dueDate              | DATE                         | Payment deadline                                    |
+| nonPaymentActionAt   | DATE                         | Earliest allowed bulk non-payment action            |
+| amount               | INTEGER                      | Minor units; nullable for draft/unknown legacy data |
+| currency             | TEXT                         | ISO code; nullable for draft/unknown legacy data    |
+| stripePriceId        | TEXT                         | Required before Stripe checkout, otherwise nullable |
+| publishedAt          | TIMESTAMPTZ                  | Null while draft                                    |
+| acceptsApplications  | BOOLEAN                      | This is the user-facing target for new applications |
+| createdAt, updatedAt | TIMESTAMPTZ                  | Standard timestamps                                 |
+| UNIQUE               | (membershipTypeId,startDate) | One period per type and start date                  |
+| PARTIAL UNIQUE       | membershipTypeId             | At most one application target per type             |
+
+A period starts as a draft. Publishing it atomically creates obligations for
+applicable active members. Publishing never creates Stripe sessions or sends
+messages.
+
+After publication, membership type, coverage dates, amount, and currency are
+locked. Admins may extend `dueDate` or `nonPaymentActionAt`, never move them
+earlier, and each change is audited. `acceptsApplications` may be moved between
+published periods with explicit confirmation. This supports opening an upcoming
+period early without deriving behavior from the calendar.
+
+New periods are pre-filled by shifting the previous period's dates. There is no
+global calendar-settings feature in this scope.
+
+### `member`
+
+| Column                     | Type                        | Notes                                                                  |
+| -------------------------- | --------------------------- | ---------------------------------------------------------------------- |
+| id                         | TEXT PK                     | Stable across resignation, rejoining, and type changes                 |
+| userId                     | TEXT FK -> user             | Null for an organization member                                        |
+| organizationName           | TEXT                        | Null for an individual member                                          |
+| status                     | ENUM                        | `awaiting_payment`, `awaiting_approval`, `active`, `ended`, `rejected` |
+| membershipTypeId           | TEXT FK -> membershipType   | Most recently board-approved type; null if never approved              |
+| pendingMembershipTypeId    | TEXT FK -> membershipType   | Type currently requested; otherwise null                               |
+| currentMembershipStartedAt | TIMESTAMPTZ                 | Start of the current or most recently ended continuous membership      |
+| applicationMotive          | TEXT                        | Latest application motive; never reused as an end reason               |
+| createdAt, updatedAt       | TIMESTAMPTZ                 | Standard timestamps                                                    |
+| CHECK                      | userId XOR organizationName | Exactly one identity form                                              |
+| PARTIAL UNIQUE             | userId                      | One stable member per individual user                                  |
+
+The approved type remains on an ended member for display. A paid applicant is
+not assigned the requested type before approval. During an active member's type
+change, `membershipTypeId` remains the old type and
+`pendingMembershipTypeId` contains the requested type.
+
+`currentMembershipStartedAt` means the latest continuous membership, not the
+first membership ever. Rejoining updates it on approval. The first join and all
+earlier intervals are retained in `membershipEvent`.
+
+### `membershipEvent`
+
+This is durable domain history. It is separate from the generic audit log,
+whose purpose is security and operational traceability and whose write failure
+must not invalidate a domain operation.
+
+| Column                | Type                           | Notes                                                    |
+| --------------------- | ------------------------------ | -------------------------------------------------------- |
+| id                    | TEXT PK                        |                                                          |
+| memberId              | TEXT FK -> member              |                                                          |
+| eventType             | ENUM                           | Typed membership transition                              |
+| effectiveAt           | TIMESTAMPTZ                    | When the change legally or inferentially took effect     |
+| recordedAt            | TIMESTAMPTZ                    | When the system recorded it                              |
+| source                | ENUM                           | `admin`, `system`, `imported`, `migration`               |
+| certainty             | ENUM                           | `confirmed` or `inferred`                                |
+| actorUserId           | TEXT FK -> user                | Nullable for migration/import                            |
+| relatedEventId        | TEXT FK -> membershipEvent     | Corrected/superseded event, when applicable              |
+| membershipFeePeriodId | TEXT FK -> membershipFeePeriod | Optional relevant period                                 |
+| data                  | JSONB                          | Event-specific, schema-validated reason and type details |
+
+Initial event types are:
+
+- `application_submitted`, `application_approved`, `application_rejected`
+- `type_change_requested`, `type_changed`, `type_change_rejected`
+- `resigned_voluntarily`, `deemed_resigned_nonpayment`, `expelled`
+- `legacy_membership_started_inferred`, `legacy_resignation_inferred`,
+  `legacy_rejoin_inferred`, `legacy_type_changed_inferred`
+- `membership_decision_corrected`
+
+Confirmed events are append-only. Correcting a mistake appends
+`membership_decision_corrected`, references the wrong event, and updates the
+current snapshot in the same transaction. Reapplying or paying is not required
+to undo an admin entry mistake.
+
+Imported inferred events are replaceable derived data. An import may delete and
+rebuild those events from the complete set of imported payment evidence, but it
+must never rewrite a confirmed event.
+
+The member activity view combines membership events and payments. Corrected
+events may be collapsed for members and remain expandable for admins.
+
+### `membershipObligation`
+
+An obligation exists only when a fee has actually been issued to a member. It
+is not backfilled for historical imports.
+
+| Column                | Type                             | Notes                                             |
+| --------------------- | -------------------------------- | ------------------------------------------------- |
+| id                    | TEXT PK                          |                                                   |
+| memberId              | TEXT FK -> member                |                                                   |
+| membershipFeePeriodId | TEXT FK -> membershipFeePeriod   |                                                   |
+| kind                  | ENUM                             | `renewal`, `application`, or `type_change`        |
+| disposition           | ENUM                             | `required`, `waived`, or `cancelled`              |
+| dispositionReason     | TEXT                             | Required for waiver; optional for cancellation    |
+| createdAt, updatedAt  | TIMESTAMPTZ                      | Standard timestamps                               |
+| UNIQUE                | (memberId,membershipFeePeriodId) | At most one issued fee for this member and period |
+
+Paid/unpaid is derived from payments and is not duplicated on the obligation.
+The three useful views are therefore:
+
+- required and settled;
+- required and unsettled;
+- waived or cancelled.
+
+Publishing a non-zero fee period for a payable type creates one `renewal`
+obligation for every currently active member of that approved type. The unique
+constraint makes publication idempotent. Free types and zero-fee periods create
+no obligations. A non-zero period cannot be published for a type whose
+`requiresPayment` is false.
+
+An admin who directly activates a member of a paid type either records a full
+manual payment or explicitly waives the applicable obligation with a reason.
+The system never fabricates a payment to explain the exception.
+
+### `payment`
+
+Each row is one real or inferred payment attempt. Retaining attempts is
+necessary for Stripe webhook idempotency and delayed payment outcomes.
+
+| Column                | Type                            | Notes                                                                                               |
+| --------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------- |
+| id                    | TEXT PK                         |                                                                                                     |
+| memberId              | TEXT FK -> member               |                                                                                                     |
+| membershipFeePeriodId | TEXT FK -> membershipFeePeriod  | Always present                                                                                      |
+| obligationId          | TEXT FK -> membershipObligation | Nullable only for historical imported/migrated evidence                                             |
+| source                | ENUM                            | `stripe`, `manual`, `imported`                                                                      |
+| status                | ENUM                            | `pending`, `succeeded`, `failed`, `expired`                                                         |
+| amount                | INTEGER                         | Minor units; nullable when historical evidence lacks it                                             |
+| currency              | TEXT                            | Nullable when historical evidence lacks it                                                          |
+| paidAt                | TIMESTAMPTZ                     | Nullable when the exact historical completion time is unknown                                       |
+| stripeSessionId       | TEXT UNIQUE                     | Nullable outside Stripe                                                                             |
+| stripePaymentIntentId | TEXT UNIQUE                     | Nullable outside Stripe                                                                             |
+| refundRequiredAt      | TIMESTAMPTZ                     | Admin must process a refund manually                                                                |
+| refundReason          | ENUM                            | `application_rejected`, `type_change_rejected`, `duplicate_payment`, `obsolete_obligation`, `other` |
+| refundConfirmedAt     | TIMESTAMPTZ                     | Refund verified from Stripe or manually confirmed                                                   |
+| stripeRefundId        | TEXT UNIQUE                     | Nullable for a non-Stripe refund                                                                    |
+| manualRefundReference | TEXT                            | Required when a non-Stripe refund is confirmed                                                      |
+| invalidatedAt         | TIMESTAMPTZ                     | Explicit correction of bad imported evidence                                                        |
+| invalidationReason    | TEXT                            | Required when invalidated                                                                           |
+| createdAt, updatedAt  | TIMESTAMPTZ                     | Standard timestamps                                                                                 |
+
+A composite foreign key from
+`payment(obligationId, memberId, membershipFeePeriodId)` to the same obligation
+columns prevents payments from being attached across members or types.
+
+Each retry creates a new payment row. Failed and expired attempts are retained,
+not deleted. Unique Stripe identifiers make webhook replay idempotent. A partial
+unique index permits at most one `pending` Stripe attempt per obligation; a new
+attempt requires the previous session to be confirmed unusable and marked
+failed or expired.
+
+The ledger must allow more than one successful payment because two real charges
+can occur despite checkout safeguards. The obligation is settled when at least
+one successful, non-refunded, non-invalidated payment exists. Any additional
+success is recorded, flagged with `refundReason = duplicate_payment`, and shown
+to admins for manual refund.
+
+A success arriving for an already cancelled or waived obligation is likewise
+recorded and queued with `refundReason = obsolete_obligation`.
+
+The first release accepts only full settlement. Stripe checkout uses the fee
+period amount and currency, and manual payments must match them.
+
+## Lifecycle and workflows
+
+### New application
+
+1. The user selects a purchasable type, not a year.
+2. The system targets that type's single published
+   `acceptsApplications` fee period. Without one, applications are unavailable.
+3. The stable member is created or reused with the target in
+   `pendingMembershipTypeId`.
+4. For a paid period, the system creates an `application` obligation and a
+   Stripe payment attempt. A free application skips checkout.
+5. Successful payment, or submission of a free application, moves a
+   never-approved applicant to `awaiting_approval` and appends
+   `application_submitted`.
+6. Board approval moves the pending type to `membershipTypeId`, sets
+   `currentMembershipStartedAt`, changes status to `active`, and appends
+   `application_approved`.
+
+Failed or abandoned checkout leaves the applicant in `awaiting_payment`.
+Returning creates a new attempt when the old Stripe session is no longer
+usable. It does not create a rejection or a membership event.
+
+Before payment succeeds, retry re-evaluates the type's current application
+period. If the admin moved applications to an upcoming period, the old
+obligation and checkout are cancelled/expired and the user sees the new dates
+and price before starting another attempt. A successful payment is never
+silently moved between periods.
+
+Board rejection appends `application_rejected`. A paid application is marked
+`refundRequiredAt`, and its application obligation is cancelled whether paid or
+unpaid. A never-approved applicant becomes `rejected`. A previously ended
+member returns to `ended`, preserving their old approved type and history. A
+later reapplication to the same period reopens the existing obligation instead
+of inserting a duplicate.
+
+### Renewal
+
+Publishing a fee period issues obligations to the active members of its type.
+Paying one changes only the obligation's derived settlement state. The member
+remains active before, during, and after payment and requires no approval.
+
+The admin overdue preset is based on:
+
+- member status is `active`;
+- obligation disposition is `required`;
+- no successful, non-refunded, non-invalidated payment settles it;
+- the obligation belongs to the relevant published fee period; and
+- the fee period's due date has passed.
+
+It does not compare `paidAt` to `dueDate`, so an applicant who joins and pays
+after the general deadline is not mistaken for an existing non-payer.
+
+### Type change during renewal
+
+Self-service type changes are available only instead of paying for a new fee
+period. They are not a general mid-period operation.
+
+1. An active member selects another eligible, purchasable type and confirms
+   that the change requires board approval.
+2. The target type's application period gets a `type_change` obligation and is
+   paid like a new membership. A free target skips payment.
+3. After payment, `pendingMembershipTypeId` is set and
+   `type_change_requested` is appended. The old approved type and active status
+   remain unchanged.
+4. While the request is pending, the old type's obligation for the same new
+   period is excluded from reminders.
+5. Approval changes the approved type, clears the pending type, appends
+   `type_changed`, and cancels the replaced old-type obligation. It does not
+   restart `currentMembershipStartedAt`.
+6. Rejection retains the old type, clears the pending type, appends
+   `type_change_rejected`, restores the old obligation to reminder views, and
+   cancels the target obligation. A successful target payment is flagged for
+   manual refund.
+
+Once the member has already settled the new period under their old type,
+self-service type change is no longer offered. Exceptional mid-period changes
+are handled manually by an admin.
+
+### Ending and rejoining
+
+`ended` is deliberately neutral. The event records whether membership ended by
+voluntary resignation, a board decision on non-payment, or expulsion.
+
+Voluntary resignation and expulsion are individual confirmed actions. The
+non-payment action is a board-triggered bulk operation and is disabled before
+`nonPaymentActionAt`; it cannot be bypassed with a warning.
+
+The bulk transaction:
+
+1. validates that every selected member is still active and still unpaid;
+2. updates each snapshot to `ended`;
+3. appends one confirmed `deemed_resigned_nonpayment` event per member; and
+4. retains the unpaid obligation as historical evidence.
+
+Notices are sent after the transaction. Delivery success or failure is recorded
+against the action, failed notices can be retried, and delivery failure never
+undoes the board decision.
+
+Rejoining uses the same stable member and the full application flow. Approval
+sets a new `currentMembershipStartedAt`; older intervals remain in events.
+
+### Overdue rights and QR verification
+
+There is no `payment_overdue` membership status. Before a confirmed ending
+action, an overdue member is legally active and remains valid in membership and
+QR checks.
+
+Admin views and QR scans may show a separate fee state:
+
+- Paid
+- Overdue
+- Not due
+- No fee
+- No obligation
+
+That information does not change access authorization.
+
+### Manual refunds
+
+The application never initiates a Stripe refund in this scope.
+
+When a paid application or type change is rejected, it sets
+`refundRequiredAt`. An admin refunds it in the Stripe Dashboard and then uses
+“Verify refund”; the server fetches Stripe's state and stores
+`refundConfirmedAt` and `stripeRefundId`. A non-Stripe refund may be confirmed
+manually with a required reference. Only a full refund clears the requirement;
+partial refunds are outside this release.
+
+A duplicate successful payment enters the same queue with
+`refundReason = duplicate_payment`. Recording the extra charge never displaces
+the earlier payment that already settled the obligation.
+
+A confirmed refund stops the payment from settling its obligation. It never
+automatically changes legal membership.
+
+### Reminders
+
+The first renewal cycle uses an admin-triggered workflow:
+
+1. Open the preset due/overdue list.
+2. Review recipients.
+3. Send a bulk reminder.
+4. Record the delivery result and last message.
+
+Schedulers, recurring reminders, and Stripe-generated invoices remain out of
+scope.
+
+### Imported uncertainty and corrections
+
+Member-facing UI shows an “imported information may be inaccurate” notice,
+including the association's contact details, only while the current snapshot
+depends on inferred legacy events. Inferred history retains a visible marker.
+
+A later confirmed event establishes authoritative current state and removes the
+current warning. Historical inferred events remain labelled. Member UI may
+collapse corrected events; admin history can expand them.
+
+## Legacy CSV import
+
+### Import lifecycle
+
+Each installation has a nullable `membershipDataLiveAt` timestamp.
+
+- **Import mode:** while it is null, admins may repeatedly import historical
+  data and rebuild inferred history.
+- **Finalize and go live:** the admin reviews a final preview and explicitly
+  establishes the live boundary.
+- **Live mode:** later imports may add history only for fee periods beginning
+  before the boundary. Rows for periods beginning on or after it are rejected.
+
+Stripe checkout is unavailable in import mode. Publishing or opening the first
+live fee period prompts the admin to finalize imports and sets
+`membershipDataLiveAt` in the same transaction. The first Stripe action never
+silently changes the mode.
+
+Historical rows imported after go-live cannot create inference at or after the
+boundary and cannot override confirmed events. This makes finalization a real
+transfer from a legacy system to this system without banning legitimate late
+historical cleanup.
+
+### Input and period calendar
+
+The canonical CSV keeps the existing exact date field:
+
+```csv
+firstNames,lastName,homeMunicipality,email,membershipTypeId,membershipStartDate
+Testi,Henkilö,Helsinki,testi@aalto.fi,varsinainen-jasen,2023-08-01
+Testi,Henkilö,Helsinki,testi@aalto.fi,varsinainen-jasen,2024-08-01
+Testi,Henkilö,Helsinki,testi@aalto.fi,ulkojasen,2025-08-01
+```
+
+`membershipStartDate` identifies the fee period. It is not treated as a payment
+timestamp or a board approval date. A legacy year-only variant may be accepted
+only when the import supplies the month/day calendar used to expand it; exact
+dates are never reduced to years.
+
+An onboarding import supplies fallback period rules for dates missing from the
+database. The preview shows them, and the import audit entry stores them with
+the inference `asOf` date. Tietokilta's production fallback is:
+
+- start: August 1;
+- end: July 31 of the following year;
+- due: September 30; and
+- earliest non-payment action: December 1.
+
+The importer creates missing historical `membershipFeePeriod` rows for the
+expected sequence between the earliest imported period and `asOf`, including
+empty periods needed to recognize a gap. These historical periods remain
+unpublished and never create obligations. If the import cannot establish an
+expected period sequence, it preserves payments but reports that lifecycle
+inference is unavailable.
+
+Historical fee amount and currency may be null when the source data does not
+contain them. Current drafts must have amount and currency before publication.
+
+### Parse and identity rules
+
+The import first parses and validates the complete file. Any row-level error
+prevents commit.
+
+1. Normalize and match individual users by email.
+2. Reject organization-member CSV rows; existing organization members are
+   preserved by production migration and managed manually.
+3. Create or reuse one stable `member` per user.
+4. For an untouched imported placeholder account, profile fields come from the
+   row with the greatest `membershipStartDate`.
+5. An older import never overwrites a newer imported profile.
+6. A verified, activated, or user-edited profile is never overwritten.
+7. Conflicting profile rows for the same email and exact date are an error.
+8. Different emails remain different users. Suspected duplicates are reported;
+   user merging is outside this RFC.
+
+### Additive payment evidence
+
+Each unique `(member, membership type, fee period)` row adds one successful
+`source = imported` payment without an obligation. `paidAt`, amount, and
+currency remain null unless the source actually supplies them.
+
+The importer is additive:
+
+- importing the same row again is a no-op;
+- file order and import order do not affect the final result;
+- absence from a later CSV never removes earlier evidence;
+- a valid existing Stripe or manual payment for the same member and period
+  means the imported row is skipped and reported as already covered; and
+- invalid imported evidence is retained with `invalidatedAt` and a reason.
+  Re-importing it remains a no-op until an admin explicitly restores it.
+
+Duplicate legacy rows for the same person, type, and period are collapsed into
+one imported payment and listed in the preview. Without a source transaction
+identifier they do not prove that two payments occurred.
+
+No historical obligations are fabricated. Fee periods, imported payment
+evidence, and inferred membership events are sufficient to represent the
+available history.
+
+### Inference algorithm
+
+After adding evidence, the importer recomputes only replaceable inferred events
+for affected members. It never deletes a member, confirmed event, payment,
+obligation, or live field in order to rebuild history.
+
+For each affected member:
+
+1. Load all non-invalidated imported payments, relevant successful live
+   payments, historical fee periods, and confirmed membership events.
+2. Remove the member's previous imported/migration events with
+   `certainty = inferred` before the live boundary, or all such events while
+   still in import mode.
+3. Sort evidence by exact period dates, independent of CSV and import order.
+4. The first legacy payment infers a membership start at the period start unless
+   a confirmed event already establishes a different state.
+5. Consecutive paid periods add payments only. They are not membership renewal
+   events.
+6. For a missing expected period, infer `legacy_resignation_inferred` at that
+   period's `nonPaymentActionAt` only when `asOf` has reached the date.
+7. A later payment after an inferred end adds `legacy_rejoin_inferred` at the
+   later period's start.
+8. A sequential change to a different type adds an inferred type-change event
+   while keeping the continuous membership. Payment evidence for mutually
+   exclusive types in the same or overlapping period is ambiguous: preserve
+   both payments, report the conflict, and infer no transition from them.
+9. Replay the combined chronological timeline into the current snapshot,
+   ignoring inferred transitions wherever they conflict with confirmed state.
+
+The December 1 Tietokilta fallback is explicitly an inference based on recent
+bulk-resignation practice. It does not claim that the board made a recorded
+decision on that date. A member whose latest missing period has a future action
+date remains inferred active. Once the live boundary is established, merely
+passing a deadline never creates a new event; only a real board action can end
+membership for a live obligation.
+
+If a later additive import fills a historical gap, the inferred end and rejoin
+events disappear on rebuild. Member UI may collapse the correction, while admin
+history and the import audit retain what happened.
+
+### Conflicts and preview
+
+Normal admin activity never blocks an import. A confirmed voluntary
+resignation, expulsion, correction, or type change simply takes precedence;
+conflicting imported inference is skipped and shown in the preview.
+
+Manual review is required only when the data cannot satisfy a core invariant,
+including:
+
+- overlapping mutually exclusive types with no authoritative current type;
+- two conflicting profile values for the same identity and exact date; or
+- a row whose type or period cannot be mapped.
+
+The preview reports created users, periods, payments, and inferred events;
+collapsed duplicates; protected live data; ambiguities; and the resulting
+current-state counts. Dry run executes the same code in a transaction and rolls
+it back.
+
+### Convergence examples
+
+All import sequences below converge after the inferred events are rebuilt:
+
+| Import sequence                            | Final evidence and inferred history                                       |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| 2023, 2024, 2025 in any order              | One stable member, three payments, one continuous membership              |
+| 2020, 2021, 2024, 2025                     | Four payments, inferred end at the 2022 action date, rejoin in 2024       |
+| Previous row set, then 2022 and 2023       | Six payments; the inferred end and rejoin disappear                       |
+| 2025 Stripe payment, then 2020–2025 import | One stable member; Stripe evidence is retained and duplicate 2025 skipped |
+| Confirmed resignation, then older import   | Payment history is added; confirmed current state remains unchanged       |
+
+## Production migration
+
+### Deployment shape
+
+Review is split into small schema, migration, workflow, and test commits. The
+production cutover itself is one transactional Drizzle schema-and-data
+migration, run with writes briefly stopped. There is no dual-write period and
+no retained compatibility tables. A database snapshot is the rollback source.
+
+The same migration also runs on fresh installations. It sets
+`membershipDataLiveAt` only when legacy member rows actually exist. An empty new
+installation remains in import mode until its admin finalizes onboarding.
+
+### Evidence classification
+
+Migration must not turn every old row into a paid payment. In particular,
+`stripeSessionId` proves that checkout was created, not that it succeeded.
+
+The migration uses this evidence in descending authority:
+
+1. Existing audit actions create confirmed board/admin events.
+2. `awaiting_approval` proves that the application payment completed.
+3. For a payable type, `active` or an old status representing previously active
+   membership is evidence of a completed purchase. A Stripe session makes its
+   payment source `stripe`; otherwise legacy period-shaped data becomes
+   `imported`. Free types establish membership evidence without a payment.
+4. An old imported active/ended period row may create a successful imported
+   payment with unknown `paidAt`, amount, and currency. Its lifecycle events
+   remain inferred unless an audit action confirms them.
+5. `awaiting_payment` proves only an attempted checkout. It becomes a pending or
+   expired payment attempt and never a successful payment.
+6. `rejected` is ambiguous. Audit history may prove a paid board rejection; if
+   it does not, preserve the rejection without inventing a successful payment
+   and list it in the rehearsal warnings.
+
+The migration never copies `member.createdAt` into `payment.paidAt`. Unknown is
+represented as null.
+
+### Transaction steps
+
+Within one migration transaction:
+
+1. Create the event, obligation, and payment structures and add the new member,
+   type, fee-period, and onboarding fields.
+2. Convert old period timestamps to `DATE` in the association timezone. For
+   Tietokilta this is `AT TIME ZONE 'Europe/Helsinki'` before the date cast, so
+   local midnight does not become the previous UTC date.
+3. Backfill Tietokilta historical due and inference dates using September 30 and
+   December 1. Mark them as migration assumptions.
+4. Collapse old per-period rows into one stable member per user or organization.
+   Preserve a deterministic existing identifier and rewire every referencing
+   row before removing duplicates.
+5. Create payments and confirmed/inferred membership events according to the
+   evidence rules above. Do not create historical obligations.
+6. Replay events to materialize `status`, approved/pending type, and
+   `currentMembershipStartedAt`.
+7. Preserve all existing organization members without attempting CSV-style
+   inference.
+8. Validate database invariants and expected classifications.
+9. Set `membershipDataLiveAt` because this installation contained live legacy
+   data, then remove obsolete period-shaped columns and rows.
+
+Any invariant failure aborts the whole transaction. Delayed Stripe webhooks
+remain safe because old session identifiers are retained on payment attempts
+rather than deleted.
+
+### Local rehearsal against production
+
+Before deployment, export a production snapshot and run the exact Drizzle
+migration against local copies. The rehearsal helper is development-only; it is
+not a deployed table or application feature.
+
+Its report includes:
+
+- before/after counts by old and new status;
+- classification counts for Stripe, imported, pending, and ambiguous payments;
+- stable-member collapses and reference rewrites;
+- inferred starts, ends, rejoins, and type changes;
+- ambiguous rejected rows and overlapping types;
+- timezone/date conversions;
+- current snapshots that still depend on inference;
+- orphan, uniqueness, and cross-type invariant checks; and
+- a comparison of two fresh-snapshot rehearsal runs to prove determinism.
+
+Detailed rows and personal data stay local. Sanitized totals and explained
+warnings may be added to the pull request. We do not have the original kide.app
+CSV exports, so importer coverage uses synthetic fixtures; the production
+snapshot validates the migration path.
+
+## Required scenario matrix
+
+The test suite should express these as data-driven domain tests where possible.
+End-to-end tests are reserved for the user, admin, Stripe webhook, and migration
+boundaries. Dates must use a fixed clock and the Europe/Helsinki timezone.
+
+### Member identity and history
+
+| Scenario                                      | Expected result                                                               |
+| --------------------------------------------- | ----------------------------------------------------------------------------- |
+| First application is approved                 | One stable member becomes active; approved type and start time are set        |
+| Active member changes type                    | Same member ID; continuous start remains; a confirmed type event is appended  |
+| Ended member rejoins                          | Same member ID; a new continuous start is set; old interval remains in events |
+| Reapplication by an ended member is rejected  | Snapshot returns to ended; rejection remains in events                        |
+| Never-approved application is rejected        | Status becomes rejected; approved type remains null                           |
+| Voluntary resignation                         | Status becomes ended with a confirmed voluntary event                         |
+| Expulsion                                     | Status becomes ended with a confirmed expulsion event                         |
+| Admin corrects a wrong ending action          | Correction event references the old event; snapshot is restored               |
+| Member has imported and confirmed history     | Confirmed state wins; inferred events stay visibly labelled                   |
+| Same user is inserted twice concurrently      | The stable-member uniqueness constraint prevents a duplicate                  |
+| Two approved types are attempted concurrently | The transaction/constraint permits only one approved current type             |
+
+### Applications and payment attempts
+
+| Scenario                                           | Expected result                                                                |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ |
+| New paid application starts checkout               | Applicant awaits payment; obligation and pending attempt exist                 |
+| Stripe checkout succeeds                           | Payment succeeds; applicant awaits approval; submission event is appended      |
+| The success webhook is replayed                    | No duplicate payment, obligation, event, or status transition                  |
+| Checkout fails or expires                          | Attempt is retained as failed/expired; applicant still awaits payment          |
+| User retries after an expired attempt              | A new attempt is created; the old attempt remains                              |
+| Application target changes before retry            | Old obligation/session closes; new dates and price require confirmation        |
+| A delayed valid webhook arrives for an old attempt | The attempt succeeds idempotently; no missing-row failure                      |
+| Delayed attempt succeeds after another payment     | Both charges are recorded; the duplicate is flagged for manual refund          |
+| Delayed payment succeeds for cancelled obligation  | Charge is recorded and flagged as obsolete for manual refund                   |
+| A second checkout starts while one is pending      | Existing usable session is resumed, or the new attempt is rejected             |
+| User returns while a session is still reusable     | Existing pending session may be resumed                                        |
+| Free purchasable type is submitted                 | No payment or obligation; applicant proceeds to board approval                 |
+| Board approves a paid application                  | Member becomes active; payment is unchanged                                    |
+| Board tries to approve before required payment     | Approval is rejected                                                           |
+| Board rejects a paid application                   | Member is rejected/returned to ended; obligation is cancelled; refund required |
+| Admin verifies the Stripe refund                   | Refund identifiers are stored and payment no longer settles the obligation     |
+| Admin confirms a non-Stripe refund                 | A manual reference is required                                                 |
+| Applicant pays after the general due date          | Approval may proceed; they never appear as an existing overdue member          |
+| Payment member/period mismatches its obligation    | Composite foreign key rejects the write                                        |
+
+### Fee periods and obligations
+
+| Scenario                                               | Expected result                                                    |
+| ------------------------------------------------------ | ------------------------------------------------------------------ |
+| Draft period is saved                                  | No obligation is created                                           |
+| Non-zero payable period is published                   | One renewal obligation per applicable active member                |
+| Publication is retried                                 | No duplicate obligations                                           |
+| Free membership type period is published               | No obligations                                                     |
+| Free type has a non-zero draft amount                  | Publication is rejected                                            |
+| Payable type has a zero-fee period                     | No obligations                                                     |
+| New active member is added after publication           | Admin records a full manual payment or a reasoned waiver           |
+| Admin directly activates a paid member without payment | Waived obligation is required; no fake payment                     |
+| Active member pays the renewal                         | Obligation settles; membership status and start time do not change |
+| Payment from the previous period exists                | New period's obligation remains unsettled                          |
+| Member has no issued obligation                        | They do not appear in due/overdue views                            |
+| Required obligation is refunded                        | It becomes unsettled; legal membership remains unchanged           |
+| Admin extends a deadline                               | Later date is saved and audited; all affected obligations use it   |
+| Admin tries to shorten a published deadline            | Operation is rejected                                              |
+| Admin edits published type, dates, amount, or currency | Operation is rejected                                              |
+| Partial or incorrectly sized manual payment is entered | Operation is rejected                                              |
+
+### Overdue, reminders, and ending membership
+
+| Scenario                                             | Expected result                                                               |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Required obligation is unpaid before due date        | Fee state is not due; member is active                                        |
+| Required obligation is unpaid after due date         | Fee state is overdue; member is still active                                  |
+| Honorary/free member                                 | Does not appear in the overdue preset                                         |
+| Obligation is waived or cancelled                    | Does not appear in the overdue preset                                         |
+| Successful payment exists                            | Does not appear in the overdue preset                                         |
+| Admin sends a reminder                               | Only reviewed eligible members are contacted; result is recorded              |
+| Scheduler time passes                                | No automatic reminder or status change occurs                                 |
+| Bulk ending is attempted before `nonPaymentActionAt` | Action is blocked                                                             |
+| Member pays between bulk preview and commit          | Member is not ended; admin sees that the row changed                          |
+| Eligible bulk action is committed                    | Member becomes ended and gets a confirmed non-payment event                   |
+| Notice delivery fails after the decision             | Ending remains committed; failed notice is visible and retryable              |
+| Ended member's old unpaid obligation is viewed       | It remains as historical unpaid evidence but not a current reminder recipient |
+| Overdue active member presents QR                    | Access remains valid; admin scan may also display “Overdue”                   |
+
+### Type changes during a new period
+
+| Scenario                                          | Expected result                                                               |
+| ------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Member selects their existing type                | Normal renewal; no board approval                                             |
+| Member selects a different eligible type          | Target obligation/payment starts; old type remains approved and active        |
+| Type-change checkout is abandoned                 | Old type and obligation remain unchanged; no pending board request            |
+| Paid type change awaits approval                  | Old obligation is suppressed from reminders; old legal type remains active    |
+| Board approves type change                        | Target type becomes approved; old obligation is cancelled; start is unchanged |
+| Board tries to approve unpaid type change         | Approval is rejected                                                          |
+| Board rejects paid type change                    | Old type/obligation remain; target obligation is cancelled; refund required   |
+| Member already paid the new period under old type | Self-service type change is unavailable; admin handles the exception          |
+| Member tries a mid-period self-service change     | Operation is unavailable                                                      |
+| Target type is free and purchasable               | Request skips checkout but still requires board approval                      |
+
+### Import identity and idempotency
+
+| Scenario                                           | Expected result                                               |
+| -------------------------------------------------- | ------------------------------------------------------------- |
+| Same CSV is imported twice                         | Second import is a no-op                                      |
+| Same rows appear in every file order               | Identical users, periods, payments, events, and snapshots     |
+| Consecutive years arrive in every import order     | One continuous inferred membership                            |
+| Later CSV omits an earlier row                     | Earlier payment evidence remains                              |
+| Duplicate row appears in one or several files      | One imported payment; duplicate warning                       |
+| Existing successful Stripe/manual payment overlaps | Imported duplicate is skipped; live payment remains           |
+| Invalidated imported row is imported again         | It stays invalidated until explicitly restored                |
+| Exact start dates are present                      | Exact dates match periods without year truncation             |
+| Year-only legacy row has a supplied calendar       | Date is expanded deterministically and assumption is audited  |
+| Year-only row has no calendar                      | Validation fails                                              |
+| Older profile row arrives last                     | It does not replace profile fields from a newer imported date |
+| Activated or user-edited account is imported       | Profile fields remain untouched                               |
+| Same email/date has conflicting profile values     | Import fails with a precise conflict                          |
+| Same person appears under different emails         | Separate users; suspected duplicate is reported               |
+| Organization row appears in CSV                    | Row is rejected as unsupported                                |
+| Dry run is requested                               | Preview equals commit result, but all writes are rolled back  |
+
+### Import inference and mixed sources
+
+| Scenario                                                  | Expected result                                                               |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Gap action date is still in the future                    | Member remains inferred active                                                |
+| Missing period's December 1 action date has passed        | Inferred end is created with imported/migration provenance                    |
+| A later paid period follows the gap                       | Inferred rejoin is created on the later period start                          |
+| Gap is filled in a later import                           | Inferred end/rejoin disappear; payments and stable member remain              |
+| Sequential periods change membership type                 | Inferred type change; continuous start remains                                |
+| Mutually exclusive types overlap                          | Payments remain; no transition inferred; review warning                       |
+| Confirmed admin resignation differs from inferred history | Import adds payment history but confirmed current state wins                  |
+| Confirmed correction exists                               | Rebuild does not restore the corrected inference                              |
+| Import mode receives another historical file              | All affected pre-live inference is rebuilt                                    |
+| Go-live is finalized                                      | Boundary is stored; Stripe/live workflows become available                    |
+| Post-live import adds a pre-boundary period               | Historical evidence/inference may be added; confirmed state remains protected |
+| Post-live import contains a post-boundary period          | Row is rejected                                                               |
+| Fresh installation runs all Drizzle migrations            | It remains in import mode because no legacy members exist                     |
+
+### Production migration
+
+| Legacy evidence                                  | Expected migrated result                                                   |
+| ------------------------------------------------ | -------------------------------------------------------------------------- |
+| `awaiting_payment` with a Stripe session         | Non-successful retained attempt; no fabricated payment                     |
+| `awaiting_approval`                              | Successful payment evidence; paid time remains unknown when absent         |
+| Payable `active` row with a Stripe session       | Successful Stripe payment evidence                                         |
+| Payable imported active/previously-active row    | Successful imported payment evidence; lifecycle certainty remains inferred |
+| Free active member                               | Membership preserved without a fake payment                                |
+| `rejected` with no proof of completed payment    | Rejected state preserved; no success invented; rehearsal warning           |
+| Audited board decision                           | Confirmed event with separate effective and recorded timestamps            |
+| Old local-midnight period timestamp              | Correct Helsinki calendar date, without UTC off-by-one                     |
+| Several period rows for one user                 | One stable member; dependencies are rewired                                |
+| Existing organization member                     | Preserved for manual management                                            |
+| Historical rows                                  | No historical obligations are created                                      |
+| Unknown payment time/amount/currency             | Nulls remain null; `createdAt` is not substituted                          |
+| Delayed Stripe webhook after migration           | Retained session ID resolves to one attempt and updates idempotently       |
+| Migration invariant fails                        | Transaction rolls back completely                                          |
+| Two rehearsals use identical snapshot and inputs | Reports and migrated domain state are identical                            |
+| Production database contains legacy members      | `membershipDataLiveAt` is set during cutover                               |
+
+## Implementation and rollout
+
+### Known blast radius
+
+Implementation must update all consumers of the old period-shaped
+`membershipId`, including schema and fixtures, application/session creation,
+Stripe webhooks, member and admin queries, import, email/reminders, QR
+verification, history UI, end-to-end tests, and developer documentation of
+member statuses.
+
+### Reviewable implementation slices
+
+Keep code review small even though production has one cutover:
+
+1. Add schema definitions, constraints, event replay, and pure domain tests.
+2. Add the production migration, local rehearsal helper, and migration fixtures.
+3. Replace legacy CSV import with preview, additive evidence, and inference.
+4. Implement fee-period publication, obligations, renewal checkout, and Stripe
+   webhook idempotency.
+5. Migrate application, reapplication, paid type-change, and manual refund
+   workflows.
+6. Add overdue/reminder views, history/provenance UI, QR fee display, and the
+   bulk non-payment action.
+
+The Drizzle migration is merged with the code that understands the new schema;
+the smaller slices are commits and review units, not independently deployed
+database states.
+
+### August-critical path
+
+Before renewals open:
+
+1. Finish schema/domain tests and the importer/migration rehearsal.
+2. Run the exact migration against a recent production snapshot early enough to
+   fix classifications, not only immediately before deployment.
+3. Reconcile rehearsal counts and explicitly classify every warning category.
+4. Complete period publication, obligation creation, renewals, new
+   applications, and new-period type changes.
+5. Verify that the overdue preset excludes free, waived, newly joined, and paid
+   members.
+6. Complete the member-facing imported-data warning and preserve legally active
+   QR behavior.
+
+The admin-triggered reminders should be ready for the first renewal cycle. The
+bulk board action and notice-retry workflow must be ready before the
+November/December non-payment decisions, but they do not need to block opening
+August payments if their data invariants and tests already exist.
+
+### Cutover runbook
+
+1. Announce a short write pause and disable application/payment/admin writes.
+2. Take and verify a restorable production snapshot.
+3. Run the already-rehearsed transactional Drizzle migration.
+4. Run invariant queries and compare counts with the rehearsal report.
+5. Smoke-test admin lists, one member history, application targeting, Stripe
+   checkout in test mode, renewal eligibility, and QR verification.
+6. Re-enable writes and monitor Stripe webhooks, payment attempts, and errors.
+
+If migration or validation fails, the transaction rolls back and the old
+application remains in place. If a post-commit smoke test finds a blocking
+problem, stop writes, restore the snapshot, and redeploy the old application.
+
+### Production readiness gate
+
+Do not open renewals until:
+
+- the exact migration succeeds on a recent snapshot;
+- all invariant checks pass with zero orphans and zero illegal type overlaps;
+- every ambiguous classification is either accepted and documented or fixed;
+- two independent rehearsal runs converge;
+- Stripe webhook replay and delayed-webhook tests pass;
+- publication retry creates no duplicate obligations;
+- the board can obtain the exact active-and-unpaid list; and
+- backup restoration has been exercised or otherwise verified.

--- a/docs/superpowers/specs/2026-04-03-membership-model-redesign.md
+++ b/docs/superpowers/specs/2026-04-03-membership-model-redesign.md
@@ -1,0 +1,381 @@
+# Membership Model Redesign
+
+## Problem
+
+The current membership data model is based on kide.app's periodic structure: each membership is a time-bounded period that users "buy into" each year. This does not reflect Finnish association law, where membership is indefinite ("toistaiseksi") with periodic payment obligations. The mismatch causes:
+
+- Old membership periods display "Eronnut" (resigned) when the member simply renewed
+- The system treats renewals as new applications, requiring unnecessary approval flows
+- The data model cannot distinguish "didn't pay this year" from "formally resigned"
+- Auto-approval logic adds complexity to work around the periodic model's limitations
+
+## Context
+
+### Legal basis
+
+Per Finnish association law and Tietokilta's bylaws (saannot):
+
+- **Membership is indefinite** until explicitly resigned or terminated (SS8-9)
+- **Payment is an annual obligation** — the annual meeting (vuosikokous) sets fees per member category (SS7)
+- **Non-payment resignation** — the board may deem a member resigned if payment is overdue by 2 months (SS8 p2)
+- **Voluntary resignation** — written notice to the board (SS8 p1)
+- **Board approval** — required for new memberships (SS26)
+
+Other guilds (Fyysikkokilta, AS) follow the same pattern with minor differences (grace periods, which types pay).
+
+### Current state
+
+The system is in production with imported data from kide.app. Approximately 3000 member records exist. The `claude/email-system-phase-2-QKOem` branch (not yet merged) adds payment reminders — it will be reimplemented on top of the new model.
+
+### Goals
+
+1. Align the data model with legal reality (indefinite membership + periodic payments)
+2. Preserve import compatibility with kide.app CSV data
+3. Simplify the renewal flow for active members (just a payment, no approval)
+4. Support order-independent, idempotent imports
+
+### Non-goals
+
+- Multi-tenancy (shared database for multiple guilds) — each deployment is single-tenant
+- Organization settings UI (hardcoded defaults for now, configurable settings planned separately)
+- Automatic status changes (all status transitions remain manual admin actions)
+- Auto-approval logic (removed entirely, can be revisited later)
+- Honorary member management UI (can be managed manually via admin for now)
+
+## Schema Design
+
+### `membershipType` (modified)
+
+| Column                      | Type                    | Notes                                                                   |
+| --------------------------- | ----------------------- | ----------------------------------------------------------------------- |
+| id                          | TEXT PK                 | e.g., "varsinainen-jasen"                                               |
+| name                        | JSONB (LocalizedString) | Display name (fi/en)                                                    |
+| description                 | JSONB (LocalizedString) | Optional description                                                    |
+| purchasable                 | BOOLEAN                 | Controls if users can buy via Stripe                                    |
+| requiresStudentVerification | BOOLEAN                 | **Moved from membershipPeriod.** If true, requires valid aalto.fi email |
+| createdAt, updatedAt        | TIMESTAMP               | Standard timestamps                                                     |
+
+Changes: `requiresStudentVerification` moved here from the period table, since it is a property of the membership type, not a yearly configuration.
+
+### `membershipPeriod` (renamed from `membership`)
+
+| Column           | Type                          | Notes                                                             |
+| ---------------- | ----------------------------- | ----------------------------------------------------------------- |
+| id               | TEXT PK                       |                                                                   |
+| membershipTypeId | TEXT FK -> membershipType     |                                                                   |
+| startDate        | DATE                          | Precise start (e.g., 2024-08-01)                                  |
+| endDate          | DATE                          | Precise end (e.g., 2025-07-31)                                    |
+| dueDate          | DATE                          | Payment due date (e.g., 2024-09-30). Nullable for legacy periods. |
+| stripePriceId    | TEXT                          | Nullable for legacy/free periods                                  |
+| UNIQUE           | (membershipTypeId, startDate) | One period per type per start date                                |
+
+The year is derived from `startDate` when needed for display or import matching — no separate column. Precise dates are set by the admin when creating periods (pre-filled from hardcoded defaults), and derived automatically during import.
+
+Hardcoded defaults (Tietokilta): period start August 1, period end July 31, due date September 30. These will be made configurable via an organization settings page in a future issue.
+
+### `member` (restructured)
+
+| Column               | Type                        | Notes                                                           |
+| -------------------- | --------------------------- | --------------------------------------------------------------- |
+| id                   | TEXT PK                     |                                                                 |
+| userId               | TEXT FK -> user             | Null for organization members                                   |
+| organizationName     | TEXT                        | Null for individual members                                     |
+| membershipTypeId     | TEXT FK -> membershipType   | The type of membership                                          |
+| status               | ENUM                        | awaiting_payment, awaiting_approval, active, resigned, rejected |
+| joinedAt             | TIMESTAMP                   | When the membership relationship started                        |
+| resignedAt           | TIMESTAMP                   | When resigned. Null if not resigned.                            |
+| description          | TEXT                        | Resignation reason, application motive, etc.                    |
+| createdAt, updatedAt | TIMESTAMP                   | Standard timestamps                                             |
+| CHECK                | userId XOR organizationName | Must have one or the other                                      |
+
+Key changes from current model:
+
+- `membershipId` FK removed — member is no longer tied to a specific period
+- `membershipTypeId` FK added — member is tied to a type directly
+- `joinedAt` and `resignedAt` added for history tracking
+- `stripeSessionId` removed (moved to `payment`)
+
+Multiple rows per user are allowed:
+
+- Different types concurrently (though only one can be `active` at a time)
+- Same type if resigned and re-joined (each "chapter" is a separate row)
+
+**Database constraint:** A partial unique index enforces at most one active membership per user (regardless of type):
+
+```sql
+CREATE UNIQUE INDEX one_active_per_user
+  ON member (userId)
+  WHERE status = 'active';
+```
+
+### `payment` (new)
+
+| Column               | Type                           | Notes                                                        |
+| -------------------- | ------------------------------ | ------------------------------------------------------------ |
+| id                   | TEXT PK                        |                                                              |
+| memberId             | TEXT FK -> member              | Which membership relationship                                |
+| membershipPeriodId   | TEXT FK -> membershipPeriod    | Which period this payment covers                             |
+| source               | ENUM                           | `imported`, `stripe`, `manual`                               |
+| paidAt               | TIMESTAMP                      | When payment was completed. **Null = checkout in progress.** |
+| stripeSessionId      | TEXT                           | Stripe checkout session ID. Null for non-Stripe.             |
+| createdAt, updatedAt | TIMESTAMP                      | Standard timestamps                                          |
+| UNIQUE               | (memberId, membershipPeriodId) | One payment per member per period                            |
+
+The `paidAt = null` state is used during active Stripe checkout sessions. This enables the resume flow: if a user navigates away and returns, the existing Stripe session can be resumed. Stale incomplete payments (e.g., older than 24h) are cleaned up periodically.
+
+## Status Transitions
+
+### Member statuses
+
+| Status            | Meaning                                                                          |
+| ----------------- | -------------------------------------------------------------------------------- |
+| awaiting_payment  | New member applied, hasn't paid yet                                              |
+| awaiting_approval | New member paid, waiting for board decision (SS26)                               |
+| active            | Board-approved, ongoing membership                                               |
+| resigned          | No longer a member — voluntary (SS8 p1), non-payment (SS8 p2), or expelled (SS9) |
+| rejected          | Board rejected application, or payment failed/expired                            |
+
+### Valid transitions
+
+```
+awaiting_payment  -> awaiting_approval  (Stripe payment succeeded)
+awaiting_payment  -> rejected           (Stripe payment failed/expired)
+awaiting_approval -> active             (board approves)
+awaiting_approval -> rejected           (board rejects)
+active            -> resigned           (admin action: voluntary, non-payment, or expulsion)
+```
+
+Re-joining after resignation or rejection always creates a **new member row** with the full application flow (`awaiting_payment -> awaiting_approval -> active`). There is no transition from resigned/rejected back to active on the same row.
+
+### What triggers resignation
+
+All resignations are manual admin actions, never automatic:
+
+- **Voluntary resignation (SS8 p1)** — member requests it, admin marks resigned
+- **Non-payment (SS8 p2)** — bulk admin action after board meeting, typically ~2 months after due date
+- **Expulsion (SS9)** — board decision for misconduct
+
+## Purchase Flows
+
+### Path A: New member applying (or re-joining after resignation)
+
+1. User picks membership type on `/new` page
+2. Fills in required info (description/motive, student verification if needed)
+3. `member` row created with status `awaiting_payment`
+4. `payment` row created with `paidAt = null`, `stripeSessionId` set
+5. User redirected to Stripe checkout
+6. Stripe succeeds -> `payment.paidAt` set, member status -> `awaiting_approval`
+7. Board approves -> member status -> `active`
+
+If Stripe fails/expires: member -> `rejected`, stale payment row cleaned up.
+
+If the user tries to apply again later: reuse an existing `awaiting_payment` member row for the same user+type rather than creating a new one. `rejected` rows are kept as historical records (rare — represents an actual board decision).
+
+### Path B: Active member paying dues
+
+1. Admin creates `membershipPeriod` for upcoming year (with Stripe price)
+2. Active members see "Payment due for [year]" in UI
+3. Member clicks pay -> `payment` row created (`paidAt = null`, `stripeSessionId` set)
+4. Stripe succeeds -> `payment.paidAt` set. **Member status unchanged, stays `active`.**
+5. If Stripe fails/expires -> stale payment row cleaned up. Member can retry.
+
+No member status changes. No approval needed. Just a payment.
+
+### Path C: Admin manually adding a member
+
+1. Admin creates `member` row directly with `active` or `awaiting_approval` status
+2. Optionally creates a `payment` row with `source: manual`
+3. Used for honorary members (no payment needed), cash payments, or edge cases
+
+### Path D: Honorary / free members
+
+1. Admin creates `member` row with status `active`
+2. Membership type has `purchasable = false`, no periods with Stripe prices
+3. Never appears in "payment due" lists. No payments needed. Indefinite.
+
+## Import Logic
+
+### CSV format
+
+```csv
+firstNames,lastName,homeMunicipality,email,membershipTypeId,year
+Testi,Henkilö,Helsinki,testi@aalto.fi,varsinainen-jasen,2020
+Testi,Henkilö,Helsinki,testi@aalto.fi,varsinainen-jasen,2021
+Testi,Henkilö,Helsinki,testi@aalto.fi,varsinainen-jasen,2022
+Testi,Henkilö,Helsinki,testi@aalto.fi,alumnijasen,2023
+```
+
+The `year` column replaces the previous `membershipStartDate`. If a full date is provided, the year is extracted (backward compatible with existing kide.app exports).
+
+### Algorithm
+
+The entire import runs within a **database transaction**. The same logic supports two modes:
+
+- **Dry run (preview)**: executes within a transaction, computes the diff, then rolls back. Returns the preview of changes to the admin for review.
+- **Commit**: executes within a transaction and commits on success.
+
+Steps:
+
+1. **Parse and validate** all CSV rows
+2. **Find or create users** by email (latest row wins for profile fields, same as current)
+3. **Find or create `membershipPeriod` rows** by (membershipTypeId, year) — dates derived from hardcoded organization defaults (period start: Aug 1, period end: Jul 31, due date: Sept 30)
+4. **Find or create `payment` rows** with `source: imported` for each (user, period) pair
+5. **Re-derive member rows** for each affected (user, membershipType) pair:
+
+#### Member row re-derivation (step 5)
+
+For each affected (user, membershipType):
+
+1. **Collect** all imported payments (where `source = imported`), sorted by period start year
+2. **Delete** all existing member rows that have **only** `source: imported` payments (protect system-created rows)
+3. **Detect continuous chains**: consecutive years with no gap form one chain
+   - Example: 2020, 2021, 2022 = one chain
+   - Example: 2020, 2021, [gap], 2024, 2025 = two chains
+4. **Create** a new `member` row for each chain:
+   - `joinedAt` = startDate of the first year's period
+   - If the chain covers the current period (i.e., today falls within the last year's period endDate or later — the member has not had a gap): `status = active`, `resignedAt = null`
+   - If the chain does not cover the current period: `status = resigned`, `resignedAt` = endDate of the last year's period
+5. **Link payments** to their respective member rows
+
+This re-derivation approach is simpler than incremental merging: delete imported member rows, re-create from scratch based on all known imported payments. Since it runs in a transaction, no data is lost on failure.
+
+#### Conflict detection
+
+Before deleting an imported-only member row, compare its current status with what the payment chain would derive. If they differ (e.g., an admin manually resigned an imported member, but payments say they should be active), the import **blocks with an error** listing the conflicting users. The admin or IT resolves the conflict manually before re-importing. This prevents the import from silently overwriting manual admin actions.
+
+#### Mixed source protection
+
+Member rows that have **any** `source: stripe` or `source: manual` payment are never deleted or modified by import. Import creates separate member rows for imported data. This ensures production data created through the live system is never altered by imports.
+
+#### Type transitions
+
+If the same user has varsinainen-jasen for 2020-2022 and alumnijasen for 2023-2025, these are two separate member rows (different types). The varsinainen row gets `status: resigned` with `resignedAt` at the end of the 2022 period.
+
+### Order independence
+
+The re-derivation step rebuilds the complete picture on every import run. This guarantees convergence regardless of import order:
+
+| Import order     | Final state                                |
+| ---------------- | ------------------------------------------ |
+| 2023, 2024, 2025 | 1 member (joined 2023, active), 3 payments |
+| 2025, 2023, 2024 | same                                       |
+| 2024, 2025, 2023 | same                                       |
+
+Gap-filling across separate imports:
+
+| Import sequence               | Final state                                            |
+| ----------------------------- | ------------------------------------------------------ |
+| First: 2020, 2021, 2024, 2025 | 2 members: (2020-2021, resigned) + (2024-2025, active) |
+| Then: 2022, 2023              | 1 member: (2020-2025, active), 6 payments              |
+
+### Source derivation for existing production data
+
+Existing data can be classified retroactively during migration:
+
+- **Payments**: no `stripeSessionId` -> `source: imported`; has `stripeSessionId` -> `source: stripe`
+- **Users**: no verified email + no `lastActiveAt` -> imported placeholder user
+
+For future imports (including by other guilds), the import flow explicitly sets `source: imported` on all created records.
+
+## Production Data Migration
+
+### Step 1: Schema changes
+
+In a single migration:
+
+1. Rename `membership` table to `membershipPeriod`
+2. Add `dueDate` column to `membershipPeriod` (set to September 30 of start year for Tietokilta)
+3. Move `requiresStudentVerification` from `membershipPeriod` to `membershipType`
+4. Restructure `member` table: add `membershipTypeId`, `joinedAt`, `resignedAt`; drop `membershipId` after data migration
+5. Create `payment` table
+
+### Step 2: Data migration
+
+1. For each existing `member` row, create a `payment` row:
+   - `membershipPeriodId` = existing `membershipId`
+   - `source` = `imported` if no `stripeSessionId`, `stripe` otherwise
+   - `paidAt` = existing `createdAt` (best available approximation)
+   - `stripeSessionId` = copied from existing member row
+
+2. Run the same re-derivation algorithm as import (step 5 above) to derive the new member rows from the complete set of payments per (user, membershipType).
+
+### Step 3: Validate
+
+- Verify total payment count matches old member row count
+- Verify every user's membership history is preserved
+- Verify active members are correctly identified
+- Spot-check specific known users
+
+This is a one-shot migration with no intermediate state. Old columns are dropped in the same migration after data is moved.
+
+## Admin Actions
+
+### Individual actions
+
+| Action         | Status change                                  | Notes                                          |
+| -------------- | ---------------------------------------------- | ---------------------------------------------- |
+| Approve member | awaiting_approval -> active                    | Board decision                                 |
+| Reject member  | awaiting_payment/awaiting_approval -> rejected | Board decision                                 |
+| Mark resigned  | active -> resigned                             | Sets resignedAt, records reason in description |
+| Create member  | -> active or awaiting_approval                 | Manual add (honorary, cash payment, etc.)      |
+
+### Bulk actions
+
+| Action                      | Notes                                                                                       |
+| --------------------------- | ------------------------------------------------------------------------------------------- |
+| Bulk approve                | Approve multiple awaiting_approval members at once                                          |
+| Bulk resign for non-payment | Mark multiple active members as resigned. Used after board meeting ~2 months past due date. |
+
+### Removed
+
+- **Auto-approval** — removed entirely. Active members don't need approval to pay dues. New/re-joining members always go through board approval.
+- **Reactivate** — removed. Re-joining creates a new member row instead.
+
+## Test Plan
+
+### Import order independence
+
+All permutations of these imports must converge to the same final state:
+
+- 3 consecutive years (e.g., 2023, 2024, 2025) in every possible order (6 permutations)
+- Years with gaps (e.g., 2020, 2021, 2024, 2025) in every possible order
+- Gap-filling: import with gap first, then fill the gap in a second import
+- All permutations should produce identical member rows and payment records
+
+### Import edge cases
+
+- Same CSV imported twice -> no duplicates (idempotency)
+- Type transition: varsinainen 2020-2022, alumni 2023-2025 -> two member rows
+- Multi-email: same person with different emails -> separate users (admin merges later)
+- Organization members: import without userId
+- Backward compatible: CSV with full dates instead of year -> year extracted
+- Dry run returns accurate preview without modifying data
+
+### Mixed source scenarios
+
+- User paid 2025 via Stripe, then import adds 2020-2024 -> system member row untouched, historical imported member row created separately
+- User was imported, then pays next period via Stripe -> payment added to existing member row with source: stripe
+- Import after system usage: imported data never modifies system-created member rows
+
+### Purchase flows
+
+- New member: full flow from application to approval
+- Active member paying dues: payment only, no status change
+- Resume checkout: navigate away, return, resume same Stripe session
+- Failed checkout: stale payment cleanup
+- Re-joining after resignation: new member row created, old history preserved
+
+### Status transitions
+
+- All valid transitions work correctly
+- Invalid transitions are rejected
+- Bulk resign sets resignedAt and records reason
+- No automatic status changes occur anywhere
+
+### Migration
+
+- Existing production data migrates correctly
+- Payment count matches old member row count
+- Active members correctly identified
+- Stripe-paid members have source: stripe on payments
+- Member history timeline is accurate for known test users

--- a/docs/superpowers/specs/2026-04-03-membership-model-redesign.md
+++ b/docs/superpowers/specs/2026-04-03-membership-model-redesign.md
@@ -44,7 +44,9 @@ resigned. QR verification and other membership rights remain valid until that
 decision.
 
 The final membership status is neutral (`ended`). The event records whether the
-reason was voluntary resignation, non-payment, or expulsion.
+reason was voluntary resignation, non-payment, or expulsion. Ending membership
+also cancels its unsettled fees; rejoining creates or reopens the applicable
+application fee instead of carrying old debt forward.
 
 ### One stable member record, with durable history
 
@@ -62,7 +64,7 @@ authoritative membership history.
 
 Publishing a fee period creates one obligation for each applicable active
 member. Publishing is idempotent and does not create Stripe checkouts or send
-messages.
+messages. Published fee dates and deadlines are immutable.
 
 Free membership types and zero-fee periods create no obligations. An admin may
 activate a paid member without inventing a payment by explicitly waiving the
@@ -71,18 +73,32 @@ obligation with a reason.
 Payment state is not duplicated on the obligation: it is paid when at least one
 successful, non-refunded payment exists.
 
-### Applications and renewals are different
+### Applications stay available and remain separate from renewals
 
 A new or returning applicant selects a membership type. The admin chooses which
 published fee period currently accepts applications, so an upcoming period can
-be opened early without calendar-specific rules.
+be opened early without calendar-specific rules. The selected fee is the
+applicant's first obligation; no earlier-period fee is created.
 
 Paid applicants go through Stripe and then wait for board approval. Free
 applicants skip payment but still wait for approval. Failed or abandoned
-checkouts stay retryable and never become board rejections.
+checkouts stay retryable and never become board rejections. Approval activates
+membership immediately even when the paid fee period starts later: fee-period
+dates never gate legal membership.
 
 An active member only pays their new obligation. Renewal does not change
-membership status or require approval.
+membership status or require approval. A type requiring student verification
+requires valid verification before renewal payment; otherwise the member must
+re-verify or request a paid, board-approved type change. Expired verification
+alone never changes membership status.
+
+A member joining late in one fee period still receives the next period's normal
+renewal obligation, even if that later period was published before approval.
+
+Every purchasable type must always have exactly one valid application target.
+Applications cannot be intentionally paused. Admins see a persistent warning
+and receive deduplicated email alerts before a target expires and if availability
+is lost.
 
 ### Type changes happen during renewal
 
@@ -119,16 +135,17 @@ Imports are additive and order-independent:
 For Tietokilta, a missing historical fee is assumed to have ended membership on
 December 1 of that fee period's starting year. This reflects the recent
 November/December bulk-resignation practice, but it is explicitly labelled as
-inferred—not as a recorded board decision.
+inferred, not as a recorded board decision.
 
 Members whose current state depends on inference see a short warning and contact
 information. A later confirmed action establishes authoritative current state;
 historical inference remains visibly labelled.
 
 Other associations choose their own historical calendar during onboarding.
-Imports may be repeated until the admin explicitly finalizes import mode.
-Afterward, CSV imports may only add history from fee periods that began before
-the go-live boundary.
+Imports may be repeated until the admin explicitly finalizes import mode. At
+finalization, the admin selects the last fully billed period for each type;
+missing-fee inference never extends beyond those cutoffs. Afterward, CSV imports
+may only add history from fee periods that began before the go-live boundary.
 
 ## Production migration
 
@@ -153,15 +170,16 @@ The migration must not manufacture evidence:
 
 The August-critical work is the migration rehearsal, fee-period publication,
 obligations, renewal checkout, applications, new-period type changes, overdue
-filter, manual reminders, and imported-data warning.
+filter, student re-verification, application-availability alerts, manual
+reminders, and imported-data warning.
 
 The bulk non-payment decision and notice retry workflow must be ready before the
 November/December board actions, but do not need to block opening August
 payments.
 
 Custom member fields, organization CSV import, automatic reminders, automatic
-refunds, individual deadline extensions, partial payments, and installments are
-outside this RFC.
+refunds, post-publication deadline changes, partial payments, and installments
+are outside this RFC.
 
 Detailed schema fields, algorithms, scenario-based tests, and the cutover
 checklist are in the

--- a/docs/superpowers/specs/2026-04-03-membership-model-redesign.md
+++ b/docs/superpowers/specs/2026-04-03-membership-model-redesign.md
@@ -84,6 +84,15 @@ These rules are the correctness boundary for the implementation:
    non-invalidated payment for that obligation.
 10. Live Stripe/manual activity and confirmed membership events always take
     precedence over imported inference.
+11. A paid application or type change cannot be approved until its target
+    obligation is settled. A direct admin activation is the separate,
+    explicitly waived exception.
+
+Membership decisions lock the stable member row and append the event plus
+snapshot update in one transaction. Payment state changes and non-payment
+actions lock the relevant obligation before deciding whether it is settled.
+Using the same member-then-obligation lock order prevents a payment/bulk-action
+race from ending a member who just paid.
 
 ## Data model
 
@@ -233,7 +242,8 @@ The three useful views are therefore:
 Publishing a non-zero fee period for a payable type creates one `renewal`
 obligation for every currently active member of that approved type. The unique
 constraint makes publication idempotent. Free types and zero-fee periods create
-no obligations.
+no obligations. A non-zero period cannot be published for a type whose
+`requiresPayment` is false.
 
 An admin who directly activates a member of a paid type either records a full
 manual payment or explicitly waives the applicable obligation with a reason.
@@ -244,26 +254,27 @@ The system never fabricates a payment to explain the exception.
 Each row is one real or inferred payment attempt. Retaining attempts is
 necessary for Stripe webhook idempotency and delayed payment outcomes.
 
-| Column                | Type                            | Notes                                                         |
-| --------------------- | ------------------------------- | ------------------------------------------------------------- |
-| id                    | TEXT PK                         |                                                               |
-| memberId              | TEXT FK -> member               |                                                               |
-| membershipFeePeriodId | TEXT FK -> membershipFeePeriod  | Always present                                                |
-| obligationId          | TEXT FK -> membershipObligation | Nullable only for historical imported/migrated evidence       |
-| source                | ENUM                            | `stripe`, `manual`, `imported`                                |
-| status                | ENUM                            | `pending`, `succeeded`, `failed`, `expired`                   |
-| amount                | INTEGER                         | Minor units; nullable when historical evidence lacks it       |
-| currency              | TEXT                            | Nullable when historical evidence lacks it                    |
-| paidAt                | TIMESTAMPTZ                     | Nullable when the exact historical completion time is unknown |
-| stripeSessionId       | TEXT UNIQUE                     | Nullable outside Stripe                                       |
-| stripePaymentIntentId | TEXT UNIQUE                     | Nullable outside Stripe                                       |
-| refundRequiredAt      | TIMESTAMPTZ                     | Admin must process a refund manually                          |
-| refundConfirmedAt     | TIMESTAMPTZ                     | Refund verified from Stripe or manually confirmed             |
-| stripeRefundId        | TEXT UNIQUE                     | Nullable for a non-Stripe refund                              |
-| manualRefundReference | TEXT                            | Required when a non-Stripe refund is confirmed                |
-| invalidatedAt         | TIMESTAMPTZ                     | Explicit correction of bad imported evidence                  |
-| invalidationReason    | TEXT                            | Required when invalidated                                     |
-| createdAt, updatedAt  | TIMESTAMPTZ                     | Standard timestamps                                           |
+| Column                | Type                            | Notes                                                                                               |
+| --------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------- |
+| id                    | TEXT PK                         |                                                                                                     |
+| memberId              | TEXT FK -> member               |                                                                                                     |
+| membershipFeePeriodId | TEXT FK -> membershipFeePeriod  | Always present                                                                                      |
+| obligationId          | TEXT FK -> membershipObligation | Nullable only for historical imported/migrated evidence                                             |
+| source                | ENUM                            | `stripe`, `manual`, `imported`                                                                      |
+| status                | ENUM                            | `pending`, `succeeded`, `failed`, `expired`                                                         |
+| amount                | INTEGER                         | Minor units; nullable when historical evidence lacks it                                             |
+| currency              | TEXT                            | Nullable when historical evidence lacks it                                                          |
+| paidAt                | TIMESTAMPTZ                     | Nullable when the exact historical completion time is unknown                                       |
+| stripeSessionId       | TEXT UNIQUE                     | Nullable outside Stripe                                                                             |
+| stripePaymentIntentId | TEXT UNIQUE                     | Nullable outside Stripe                                                                             |
+| refundRequiredAt      | TIMESTAMPTZ                     | Admin must process a refund manually                                                                |
+| refundReason          | ENUM                            | `application_rejected`, `type_change_rejected`, `duplicate_payment`, `obsolete_obligation`, `other` |
+| refundConfirmedAt     | TIMESTAMPTZ                     | Refund verified from Stripe or manually confirmed                                                   |
+| stripeRefundId        | TEXT UNIQUE                     | Nullable for a non-Stripe refund                                                                    |
+| manualRefundReference | TEXT                            | Required when a non-Stripe refund is confirmed                                                      |
+| invalidatedAt         | TIMESTAMPTZ                     | Explicit correction of bad imported evidence                                                        |
+| invalidationReason    | TEXT                            | Required when invalidated                                                                           |
+| createdAt, updatedAt  | TIMESTAMPTZ                     | Standard timestamps                                                                                 |
 
 A composite foreign key from
 `payment(obligationId, memberId, membershipFeePeriodId)` to the same obligation
@@ -271,8 +282,18 @@ columns prevents payments from being attached across members or types.
 
 Each retry creates a new payment row. Failed and expired attempts are retained,
 not deleted. Unique Stripe identifiers make webhook replay idempotent. A partial
-unique index permits at most one successful, non-refunded, non-invalidated
-payment per obligation.
+unique index permits at most one `pending` Stripe attempt per obligation; a new
+attempt requires the previous session to be confirmed unusable and marked
+failed or expired.
+
+The ledger must allow more than one successful payment because two real charges
+can occur despite checkout safeguards. The obligation is settled when at least
+one successful, non-refunded, non-invalidated payment exists. Any additional
+success is recorded, flagged with `refundReason = duplicate_payment`, and shown
+to admins for manual refund.
+
+A success arriving for an already cancelled or waived obligation is likewise
+recorded and queued with `refundReason = obsolete_obligation`.
 
 The first release accepts only full settlement. Stripe checkout uses the fee
 period amount and currency, and manual payments must match them.
@@ -299,10 +320,18 @@ Failed or abandoned checkout leaves the applicant in `awaiting_payment`.
 Returning creates a new attempt when the old Stripe session is no longer
 usable. It does not create a rejection or a membership event.
 
+Before payment succeeds, retry re-evaluates the type's current application
+period. If the admin moved applications to an upcoming period, the old
+obligation and checkout are cancelled/expired and the user sees the new dates
+and price before starting another attempt. A successful payment is never
+silently moved between periods.
+
 Board rejection appends `application_rejected`. A paid application is marked
-`refundRequiredAt`; an unpaid application obligation is cancelled. A
-never-approved applicant becomes `rejected`. A previously ended member returns
-to `ended`, preserving their old approved type and history.
+`refundRequiredAt`, and its application obligation is cancelled whether paid or
+unpaid. A never-approved applicant becomes `rejected`. A previously ended
+member returns to `ended`, preserving their old approved type and history. A
+later reapplication to the same period reopens the existing obligation instead
+of inserting a duplicate.
 
 ### Renewal
 
@@ -340,7 +369,8 @@ period. They are not a general mid-period operation.
    restart `currentMembershipStartedAt`.
 6. Rejection retains the old type, clears the pending type, appends
    `type_change_rejected`, restores the old obligation to reminder views, and
-   flags the target payment for manual refund.
+   cancels the target obligation. A successful target payment is flagged for
+   manual refund.
 
 Once the member has already settled the new period under their old type,
 self-service type change is no longer offered. Exceptional mid-period changes
@@ -393,7 +423,12 @@ When a paid application or type change is rejected, it sets
 `refundRequiredAt`. An admin refunds it in the Stripe Dashboard and then uses
 “Verify refund”; the server fetches Stripe's state and stores
 `refundConfirmedAt` and `stripeRefundId`. A non-Stripe refund may be confirmed
-manually with a required reference.
+manually with a required reference. Only a full refund clears the requirement;
+partial refunds are outside this release.
+
+A duplicate successful payment enters the same queue with
+`refundReason = duplicate_payment`. Recording the extra charge never displaces
+the earlier payment that already settled the obligation.
 
 A confirmed refund stops the payment from settling its obligation. It never
 automatically changes legal membership.
@@ -678,51 +713,251 @@ warnings may be added to the pull request. We do not have the original kide.app
 CSV exports, so importer coverage uses synthetic fixtures; the production
 snapshot validates the migration path.
 
-## Test Plan
+## Decision rationale
 
-### Import order independence
+| Decision                                | Rationale                                                                | Alternative not chosen                                                   |
+| --------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| One stable member plus domain events    | Keeps identity stable through type changes, endings, and rejoins         | Multiple “membership chapter” rows recreate the current model's problem  |
+| Explicit issued obligations             | Represents who actually owes a fee, including waivers and late additions | Inferring debt from missing payments misclassifies free and new members  |
+| No overdue membership status            | Non-payment does not alter legal membership before a board action        | Automatic status changes violate the legal and product invariant         |
+| Replaceable inferred legacy events      | Reviewing about 3,000 imported members individually is not feasible      | Treating guesses as confirmed decisions creates false legal history      |
+| Additive imports                        | Missing rows and file order cannot erase known evidence                  | Snapshot-style import makes later partial files destructive              |
+| Exact dates plus an explicit calendar   | Preserves source precision and makes legacy assumptions visible          | Reducing dates to years loses information and hides the inference policy |
+| One rehearsed production migration      | The cutover is small enough to make dual writes unnecessary              | A long compatibility phase adds code and another source of inconsistency |
+| Manual Stripe refunds with verification | Refunds are very rare, while their accounting state still matters        | Automatic refund execution adds risk without helping the renewal launch  |
+| One explicit application target         | Handles early upcoming-period sales without calendar-specific branching  | Automatically choosing by month recreates the July/August ambiguity      |
 
-All permutations of these imports must converge to the same final state:
+## Required scenario matrix
 
-- 3 consecutive years (e.g., 2023, 2024, 2025) in every possible order (6 permutations)
-- Years with gaps (e.g., 2020, 2021, 2024, 2025) in every possible order
-- Gap-filling: import with gap first, then fill the gap in a second import
-- All permutations should produce identical member rows and payment records
+The test suite should express these as data-driven domain tests where possible.
+End-to-end tests are reserved for the user, admin, Stripe webhook, and migration
+boundaries. Dates must use a fixed clock and the Europe/Helsinki timezone.
 
-### Import edge cases
+### Member identity and history
 
-- Same CSV imported twice -> no duplicates (idempotency)
-- Type transition: varsinainen 2020-2022, alumni 2023-2025 -> two member rows
-- Multi-email: same person with different emails -> separate users (admin merges later)
-- Organization members: import without userId
-- Backward compatible: CSV with full dates instead of year -> year extracted
-- Dry run returns accurate preview without modifying data
+| Scenario                                      | Expected result                                                               |
+| --------------------------------------------- | ----------------------------------------------------------------------------- |
+| First application is approved                 | One stable member becomes active; approved type and start time are set        |
+| Active member changes type                    | Same member ID; continuous start remains; a confirmed type event is appended  |
+| Ended member rejoins                          | Same member ID; a new continuous start is set; old interval remains in events |
+| Reapplication by an ended member is rejected  | Snapshot returns to ended; rejection remains in events                        |
+| Never-approved application is rejected        | Status becomes rejected; approved type remains null                           |
+| Voluntary resignation                         | Status becomes ended with a confirmed voluntary event                         |
+| Expulsion                                     | Status becomes ended with a confirmed expulsion event                         |
+| Admin corrects a wrong ending action          | Correction event references the old event; snapshot is restored               |
+| Member has imported and confirmed history     | Confirmed state wins; inferred events stay visibly labelled                   |
+| Same user is inserted twice concurrently      | The stable-member uniqueness constraint prevents a duplicate                  |
+| Two approved types are attempted concurrently | The transaction/constraint permits only one approved current type             |
 
-### Mixed source scenarios
+### Applications and payment attempts
 
-- User paid 2025 via Stripe, then import adds 2020-2024 -> system member row untouched, historical imported member row created separately
-- User was imported, then pays next period via Stripe -> payment added to existing member row with source: stripe
-- Import after system usage: imported data never modifies system-created member rows
+| Scenario                                           | Expected result                                                                |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ |
+| New paid application starts checkout               | Applicant awaits payment; obligation and pending attempt exist                 |
+| Stripe checkout succeeds                           | Payment succeeds; applicant awaits approval; submission event is appended      |
+| The success webhook is replayed                    | No duplicate payment, obligation, event, or status transition                  |
+| Checkout fails or expires                          | Attempt is retained as failed/expired; applicant still awaits payment          |
+| User retries after an expired attempt              | A new attempt is created; the old attempt remains                              |
+| Application target changes before retry            | Old obligation/session closes; new dates and price require confirmation        |
+| A delayed valid webhook arrives for an old attempt | The attempt succeeds idempotently; no missing-row failure                      |
+| Delayed attempt succeeds after another payment     | Both charges are recorded; the duplicate is flagged for manual refund          |
+| Delayed payment succeeds for cancelled obligation  | Charge is recorded and flagged as obsolete for manual refund                   |
+| A second checkout starts while one is pending      | Existing usable session is resumed, or the new attempt is rejected             |
+| User returns while a session is still reusable     | Existing pending session may be resumed                                        |
+| Free purchasable type is submitted                 | No payment or obligation; applicant proceeds to board approval                 |
+| Board approves a paid application                  | Member becomes active; payment is unchanged                                    |
+| Board tries to approve before required payment     | Approval is rejected                                                           |
+| Board rejects a paid application                   | Member is rejected/returned to ended; obligation is cancelled; refund required |
+| Admin verifies the Stripe refund                   | Refund identifiers are stored and payment no longer settles the obligation     |
+| Admin confirms a non-Stripe refund                 | A manual reference is required                                                 |
+| Applicant pays after the general due date          | Approval may proceed; they never appear as an existing overdue member          |
+| Payment member/period mismatches its obligation    | Composite foreign key rejects the write                                        |
 
-### Purchase flows
+### Fee periods and obligations
 
-- New member: full flow from application to approval
-- Active member paying dues: payment only, no status change
-- Resume checkout: navigate away, return, resume same Stripe session
-- Failed checkout: stale payment cleanup
-- Re-joining after resignation: new member row created, old history preserved
+| Scenario                                               | Expected result                                                    |
+| ------------------------------------------------------ | ------------------------------------------------------------------ |
+| Draft period is saved                                  | No obligation is created                                           |
+| Non-zero payable period is published                   | One renewal obligation per applicable active member                |
+| Publication is retried                                 | No duplicate obligations                                           |
+| Free membership type period is published               | No obligations                                                     |
+| Free type has a non-zero draft amount                  | Publication is rejected                                            |
+| Payable type has a zero-fee period                     | No obligations                                                     |
+| New active member is added after publication           | Admin records a full manual payment or a reasoned waiver           |
+| Admin directly activates a paid member without payment | Waived obligation is required; no fake payment                     |
+| Active member pays the renewal                         | Obligation settles; membership status and start time do not change |
+| Payment from the previous period exists                | New period's obligation remains unsettled                          |
+| Member has no issued obligation                        | They do not appear in due/overdue views                            |
+| Required obligation is refunded                        | It becomes unsettled; legal membership remains unchanged           |
+| Admin extends a deadline                               | Later date is saved and audited; all affected obligations use it   |
+| Admin tries to shorten a published deadline            | Operation is rejected                                              |
+| Admin edits published type, dates, amount, or currency | Operation is rejected                                              |
+| Partial or incorrectly sized manual payment is entered | Operation is rejected                                              |
 
-### Status transitions
+### Overdue, reminders, and ending membership
 
-- All valid transitions work correctly
-- Invalid transitions are rejected
-- Bulk resign sets resignedAt and records reason
-- No automatic status changes occur anywhere
+| Scenario                                             | Expected result                                                               |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Required obligation is unpaid before due date        | Fee state is not due; member is active                                        |
+| Required obligation is unpaid after due date         | Fee state is overdue; member is still active                                  |
+| Honorary/free member                                 | Does not appear in the overdue preset                                         |
+| Obligation is waived or cancelled                    | Does not appear in the overdue preset                                         |
+| Successful payment exists                            | Does not appear in the overdue preset                                         |
+| Admin sends a reminder                               | Only reviewed eligible members are contacted; result is recorded              |
+| Scheduler time passes                                | No automatic reminder or status change occurs                                 |
+| Bulk ending is attempted before `nonPaymentActionAt` | Action is blocked                                                             |
+| Member pays between bulk preview and commit          | Member is not ended; admin sees that the row changed                          |
+| Eligible bulk action is committed                    | Member becomes ended and gets a confirmed non-payment event                   |
+| Notice delivery fails after the decision             | Ending remains committed; failed notice is visible and retryable              |
+| Ended member's old unpaid obligation is viewed       | It remains as historical unpaid evidence but not a current reminder recipient |
+| Overdue active member presents QR                    | Access remains valid; admin scan may also display “Overdue”                   |
 
-### Migration
+### Type changes during a new period
 
-- Existing production data migrates correctly
-- Payment count matches old member row count
-- Active members correctly identified
-- Stripe-paid members have source: stripe on payments
-- Member history timeline is accurate for known test users
+| Scenario                                          | Expected result                                                               |
+| ------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Member selects their existing type                | Normal renewal; no board approval                                             |
+| Member selects a different eligible type          | Target obligation/payment starts; old type remains approved and active        |
+| Type-change checkout is abandoned                 | Old type and obligation remain unchanged; no pending board request            |
+| Paid type change awaits approval                  | Old obligation is suppressed from reminders; old legal type remains active    |
+| Board approves type change                        | Target type becomes approved; old obligation is cancelled; start is unchanged |
+| Board tries to approve unpaid type change         | Approval is rejected                                                          |
+| Board rejects paid type change                    | Old type/obligation remain; target obligation is cancelled; refund required   |
+| Member already paid the new period under old type | Self-service type change is unavailable; admin handles the exception          |
+| Member tries a mid-period self-service change     | Operation is unavailable                                                      |
+| Target type is free and purchasable               | Request skips checkout but still requires board approval                      |
+
+### Import identity and idempotency
+
+| Scenario                                           | Expected result                                               |
+| -------------------------------------------------- | ------------------------------------------------------------- |
+| Same CSV is imported twice                         | Second import is a no-op                                      |
+| Same rows appear in every file order               | Identical users, periods, payments, events, and snapshots     |
+| Consecutive years arrive in every import order     | One continuous inferred membership                            |
+| Later CSV omits an earlier row                     | Earlier payment evidence remains                              |
+| Duplicate row appears in one or several files      | One imported payment; duplicate warning                       |
+| Existing successful Stripe/manual payment overlaps | Imported duplicate is skipped; live payment remains           |
+| Invalidated imported row is imported again         | It stays invalidated until explicitly restored                |
+| Exact start dates are present                      | Exact dates match periods without year truncation             |
+| Year-only legacy row has a supplied calendar       | Date is expanded deterministically and assumption is audited  |
+| Year-only row has no calendar                      | Validation fails                                              |
+| Older profile row arrives last                     | It does not replace profile fields from a newer imported date |
+| Activated or user-edited account is imported       | Profile fields remain untouched                               |
+| Same email/date has conflicting profile values     | Import fails with a precise conflict                          |
+| Same person appears under different emails         | Separate users; suspected duplicate is reported               |
+| Organization row appears in CSV                    | Row is rejected as unsupported                                |
+| Dry run is requested                               | Preview equals commit result, but all writes are rolled back  |
+
+### Import inference and mixed sources
+
+| Scenario                                                  | Expected result                                                               |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Gap action date is still in the future                    | Member remains inferred active                                                |
+| Missing period's December 1 action date has passed        | Inferred end is created with imported/migration provenance                    |
+| A later paid period follows the gap                       | Inferred rejoin is created on the later period start                          |
+| Gap is filled in a later import                           | Inferred end/rejoin disappear; payments and stable member remain              |
+| Sequential periods change membership type                 | Inferred type change; continuous start remains                                |
+| Mutually exclusive types overlap                          | Payments remain; no transition inferred; review warning                       |
+| Confirmed admin resignation differs from inferred history | Import adds payment history but confirmed current state wins                  |
+| Confirmed correction exists                               | Rebuild does not restore the corrected inference                              |
+| Import mode receives another historical file              | All affected pre-live inference is rebuilt                                    |
+| Go-live is finalized                                      | Boundary is stored; Stripe/live workflows become available                    |
+| Post-live import adds a pre-boundary period               | Historical evidence/inference may be added; confirmed state remains protected |
+| Post-live import contains a post-boundary period          | Row is rejected                                                               |
+| Fresh installation runs all Drizzle migrations            | It remains in import mode because no legacy members exist                     |
+
+### Production migration
+
+| Legacy evidence                                  | Expected migrated result                                                   |
+| ------------------------------------------------ | -------------------------------------------------------------------------- |
+| `awaiting_payment` with a Stripe session         | Non-successful retained attempt; no fabricated payment                     |
+| `awaiting_approval`                              | Successful payment evidence; paid time remains unknown when absent         |
+| Payable `active` row with a Stripe session       | Successful Stripe payment evidence                                         |
+| Payable imported active/previously-active row    | Successful imported payment evidence; lifecycle certainty remains inferred |
+| Free active member                               | Membership preserved without a fake payment                                |
+| `rejected` with no proof of completed payment    | Rejected state preserved; no success invented; rehearsal warning           |
+| Audited board decision                           | Confirmed event with separate effective and recorded timestamps            |
+| Old local-midnight period timestamp              | Correct Helsinki calendar date, without UTC off-by-one                     |
+| Several period rows for one user                 | One stable member; dependencies are rewired                                |
+| Existing organization member                     | Preserved for manual management                                            |
+| Historical rows                                  | No historical obligations are created                                      |
+| Unknown payment time/amount/currency             | Nulls remain null; `createdAt` is not substituted                          |
+| Delayed Stripe webhook after migration           | Retained session ID resolves to one attempt and updates idempotently       |
+| Migration invariant fails                        | Transaction rolls back completely                                          |
+| Two rehearsals use identical snapshot and inputs | Reports and migrated domain state are identical                            |
+| Production database contains legacy members      | `membershipDataLiveAt` is set during cutover                               |
+
+## Implementation and rollout
+
+### Known blast radius
+
+Implementation must update all consumers of the old period-shaped
+`membershipId`, including schema and fixtures, application/session creation,
+Stripe webhooks, member and admin queries, import, email/reminders, QR
+verification, history UI, end-to-end tests, and developer documentation of
+member statuses.
+
+### Reviewable implementation slices
+
+Keep code review small even though production has one cutover:
+
+1. Add schema definitions, constraints, event replay, and pure domain tests.
+2. Add the production migration, local rehearsal helper, and migration fixtures.
+3. Replace legacy CSV import with preview, additive evidence, and inference.
+4. Implement fee-period publication, obligations, renewal checkout, and Stripe
+   webhook idempotency.
+5. Migrate application, reapplication, paid type-change, and manual refund
+   workflows.
+6. Add overdue/reminder views, history/provenance UI, QR fee display, and the
+   bulk non-payment action.
+
+The Drizzle migration is merged with the code that understands the new schema;
+the smaller slices are commits and review units, not independently deployed
+database states.
+
+### August-critical path
+
+Before renewals open:
+
+1. Finish schema/domain tests and the importer/migration rehearsal.
+2. Run the exact migration against a recent production snapshot early enough to
+   fix classifications, not only immediately before deployment.
+3. Reconcile rehearsal counts and explicitly classify every warning category.
+4. Complete period publication, obligation creation, renewals, new
+   applications, and new-period type changes.
+5. Verify that the overdue preset excludes free, waived, newly joined, and paid
+   members.
+6. Complete the member-facing imported-data warning and preserve legally active
+   QR behavior.
+
+The admin-triggered reminders should be ready for the first renewal cycle. The
+bulk board action and notice-retry workflow must be ready before the
+November/December non-payment decisions, but they do not need to block opening
+August payments if their data invariants and tests already exist.
+
+### Cutover runbook
+
+1. Announce a short write pause and disable application/payment/admin writes.
+2. Take and verify a restorable production snapshot.
+3. Run the already-rehearsed transactional Drizzle migration.
+4. Run invariant queries and compare counts with the rehearsal report.
+5. Smoke-test admin lists, one member history, application targeting, Stripe
+   checkout in test mode, renewal eligibility, and QR verification.
+6. Re-enable writes and monitor Stripe webhooks, payment attempts, and errors.
+
+If migration or validation fails, the transaction rolls back and the old
+application remains in place. If a post-commit smoke test finds a blocking
+problem, stop writes, restore the snapshot, and redeploy the old application.
+
+### Production readiness gate
+
+Do not open renewals until:
+
+- the exact migration succeeds on a recent snapshot;
+- all invariant checks pass with zero orphans and zero illegal type overlaps;
+- every ambiguous classification is either accepted and documented or fixed;
+- two independent rehearsal runs converge;
+- Stripe webhook replay and delayed-webhook tests pass;
+- publication retry creates no duplicate obligations;
+- the board can obtain the exact active-and-unpaid list; and
+- backup restoration has been exercised or otherwise verified.

--- a/docs/superpowers/specs/2026-04-03-membership-model-redesign.md
+++ b/docs/superpowers/specs/2026-04-03-membership-model-redesign.md
@@ -1,197 +1,424 @@
 # Membership Model Redesign
 
-## Problem
+## Decision summary
 
-The current membership data model is based on kide.app's periodic structure: each membership is a time-bounded period that users "buy into" each year. This does not reflect Finnish association law, where membership is indefinite ("toistaiseksi") with periodic payment obligations. The mismatch causes:
+Legal membership is indefinite. A yearly fee is an obligation attached to an
+already-existing membership, not a new membership chapter.
 
-- Old membership periods display "Eronnut" (resigned) when the member simply renewed
-- The system treats renewals as new applications, requiring unnecessary approval flows
-- The data model cannot distinguish "didn't pay this year" from "formally resigned"
-- Auto-approval logic adds complexity to work around the periodic model's limitations
+The redesigned model therefore separates five facts:
+
+1. `member` is the current legal snapshot for one person or organization.
+2. `membershipEvent` is the durable history of legal membership decisions.
+3. `membershipFeePeriod` defines one type's fee and deadlines for a period.
+4. `membershipObligation` records that a particular member was issued that fee.
+5. `payment` records money and payment attempts.
+
+This is deliberately not full event sourcing. Current lists read the `member`
+snapshot; history reads immutable domain events. Payments remain their own
+financial records.
 
 ## Context
 
-### Legal basis
+### Problem
 
-Per Finnish association law and Tietokilta's bylaws (saannot):
+The current model copies kide.app: a membership is a product with start and end
+times that a user buys each year. This creates false membership chapters,
+displays old periods as resignations, and sends renewals through an application
+approval flow.
 
-- **Membership is indefinite** until explicitly resigned or terminated (SS8-9)
-- **Payment is an annual obligation** — the annual meeting (vuosikokous) sets fees per member category (SS7)
-- **Non-payment resignation** — the board may deem a member resigned if payment is overdue by 2 months (SS8 p2)
-- **Voluntary resignation** — written notice to the board (SS8 p1)
-- **Board approval** — required for new memberships (SS26)
+That model does not match Tietokilta's rules:
 
-Other guilds (Fyysikkokilta, AS) follow the same pattern with minor differences (grace periods, which types pay).
+- Membership continues until it is ended under sections 8 or 9.
+- The annual meeting sets fees by membership category under section 7.
+- The board may deem a member resigned after the fee has been overdue for two
+  months, but non-payment does not itself end membership.
+- A new member requires the board decision described in section 25(4).
+
+Other associations have different fee categories and deadlines, but the same
+separation between legal membership and fees is broadly useful.
 
 ### Current state
 
-The system is in production with imported data from kide.app. Approximately 3000 member records exist. The `claude/email-system-phase-2-QKOem` branch (not yet merged) adds payment reminders — it will be reimplemented on top of the new model.
+The production database contains roughly 3,000 old period-shaped member rows,
+including data imported from kide.app and rows created by the live Stripe flow.
+Their history cannot be reconstructed perfectly. Migration must preserve the
+available evidence, identify inference as inference, and establish a correct
+model going forward.
 
 ### Goals
 
-1. Align the data model with legal reality (indefinite membership + periodic payments)
-2. Preserve import compatibility with kide.app CSV data
-3. Simplify the renewal flow for active members (just a payment, no approval)
-4. Support order-independent, idempotent imports
+1. Represent indefinite membership and mutually exclusive membership types.
+2. Keep renewals as payments without a new board approval.
+3. Give the board an explicit, safe non-payment workflow.
+4. Preserve legal history without treating an audit log as domain data.
+5. Support deterministic, additive, order-independent legacy imports.
+6. Migrate the current production database in one rehearsed transaction.
 
 ### Non-goals
 
-- Multi-tenancy (shared database for multiple guilds) — each deployment is single-tenant
-- Organization settings UI (hardcoded defaults for now, configurable settings planned separately)
-- Automatic status changes (all status transitions remain manual admin actions)
-- Auto-approval logic (removed entirely, can be revisited later)
-- Honorary member management UI (can be managed manually via admin for now)
+- Automatic reminders or automatic membership status changes
+- Stripe Invoicing or automatic Stripe refunds
+- Partial payments, installments, discounts, or moving credit between periods
+- Individual deadline extensions in the first release
+- Importing organization members from CSV
+- Custom member fields
+- Bulk correction tooling for confirmed board decisions
+- Multi-tenancy
 
-## Schema Design
+## Invariants
 
-### `membershipType` (modified)
+These rules are the correctness boundary for the implementation:
 
-| Column                      | Type                    | Notes                                                                   |
-| --------------------------- | ----------------------- | ----------------------------------------------------------------------- |
-| id                          | TEXT PK                 | e.g., "varsinainen-jasen"                                               |
-| name                        | JSONB (LocalizedString) | Display name (fi/en)                                                    |
-| description                 | JSONB (LocalizedString) | Optional description                                                    |
-| purchasable                 | BOOLEAN                 | Controls if users can buy via Stripe                                    |
-| requiresStudentVerification | BOOLEAN                 | **Moved from membershipPeriod.** If true, requires valid aalto.fi email |
-| createdAt, updatedAt        | TIMESTAMP               | Standard timestamps                                                     |
+1. One person or organization has one stable `member` aggregate.
+2. A member has at most one approved membership type at a time.
+3. Paying a renewal never approves, renews, or ends legal membership.
+4. No failed, expired, or abandoned checkout rejects an application.
+5. Only a confirmed board/admin action changes an active membership to `ended`.
+6. Overdue members retain all membership rights until that action, including QR
+   verification and member-only access.
+7. Imported inference may be rebuilt. Confirmed events are immutable and may
+   only be corrected by a new event.
+8. A fee is due only when a `required` obligation exists. Lack of a payment row
+   alone does not create a debt.
+9. A required obligation is settled only by a successful, non-refunded,
+   non-invalidated payment for that obligation.
+10. Live Stripe/manual activity and confirmed membership events always take
+    precedence over imported inference.
 
-Changes: `requiresStudentVerification` moved here from the period table, since it is a property of the membership type, not a yearly configuration.
+## Data model
 
-### `membershipPeriod` (renamed from `membership`)
+Names below use application-level camel case. Database migrations continue to
+use the project's snake-case convention.
 
-| Column           | Type                          | Notes                                                             |
-| ---------------- | ----------------------------- | ----------------------------------------------------------------- |
-| id               | TEXT PK                       |                                                                   |
-| membershipTypeId | TEXT FK -> membershipType     |                                                                   |
-| startDate        | DATE                          | Precise start (e.g., 2024-08-01)                                  |
-| endDate          | DATE                          | Precise end (e.g., 2025-07-31)                                    |
-| dueDate          | DATE                          | Payment due date (e.g., 2024-09-30). Nullable for legacy periods. |
-| stripePriceId    | TEXT                          | Nullable for legacy/free periods                                  |
-| UNIQUE           | (membershipTypeId, startDate) | One period per type per start date                                |
+### `membershipType`
 
-The year is derived from `startDate` when needed for display or import matching — no separate column. Precise dates are set by the admin when creating periods (pre-filled from hardcoded defaults), and derived automatically during import.
+| Column                      | Type                    | Notes                                                 |
+| --------------------------- | ----------------------- | ----------------------------------------------------- |
+| id                          | TEXT PK                 | Stable identifier, for example `varsinainen-jasen`    |
+| name                        | JSONB (LocalizedString) | Display name                                          |
+| description                 | JSONB (LocalizedString) | Optional description                                  |
+| purchasable                 | BOOLEAN                 | Users may select this type themselves                 |
+| requiresPayment             | BOOLEAN                 | Members of this type normally receive annual fee dues |
+| requiresStudentVerification | BOOLEAN                 | Requires the configured student identity verification |
+| createdAt, updatedAt        | TIMESTAMPTZ             | Standard timestamps                                   |
 
-Hardcoded defaults (Tietokilta): period start August 1, period end July 31, due date September 30. These will be made configurable via an organization settings page in a future issue.
+`purchasable` and `requiresPayment` are independent. For example, an honorary
+type may be neither purchasable nor payable. A type may also be free for a
+particular period by publishing a zero-fee period.
 
-### `member` (restructured)
+### `membershipFeePeriod`
 
-| Column               | Type                        | Notes                                                           |
-| -------------------- | --------------------------- | --------------------------------------------------------------- |
-| id                   | TEXT PK                     |                                                                 |
-| userId               | TEXT FK -> user             | Null for organization members                                   |
-| organizationName     | TEXT                        | Null for individual members                                     |
-| membershipTypeId     | TEXT FK -> membershipType   | The type of membership                                          |
-| status               | ENUM                        | awaiting_payment, awaiting_approval, active, resigned, rejected |
-| joinedAt             | TIMESTAMP                   | When the membership relationship started                        |
-| resignedAt           | TIMESTAMP                   | When resigned. Null if not resigned.                            |
-| description          | TEXT                        | Resignation reason, application motive, etc.                    |
-| createdAt, updatedAt | TIMESTAMP                   | Standard timestamps                                             |
-| CHECK                | userId XOR organizationName | Must have one or the other                                      |
+This replaces the misleading `membershipPeriod` name. It describes a fee and
+application target, not the duration of legal membership.
 
-Key changes from current model:
+| Column               | Type                         | Notes                                                 |
+| -------------------- | ---------------------------- | ----------------------------------------------------- |
+| id                   | TEXT PK                      |                                                       |
+| membershipTypeId     | TEXT FK -> membershipType    |                                                       |
+| startDate            | DATE                         | Coverage/display start                                |
+| endDate              | DATE                         | Coverage/display end                                  |
+| dueDate              | DATE                         | Payment deadline                                      |
+| nonPaymentActionAt   | DATE                         | Earliest allowed bulk non-payment action              |
+| amount               | INTEGER                      | Minor currency units; zero means free for this period |
+| currency             | TEXT                         | ISO currency code                                     |
+| stripePriceId        | TEXT                         | Required before Stripe checkout, otherwise nullable   |
+| publishedAt          | TIMESTAMPTZ                  | Null while draft                                      |
+| acceptsApplications  | BOOLEAN                      | This is the user-facing target for new applications   |
+| createdAt, updatedAt | TIMESTAMPTZ                  | Standard timestamps                                   |
+| UNIQUE               | (membershipTypeId,startDate) | One period per type and start date                    |
+| PARTIAL UNIQUE       | membershipTypeId             | At most one application target per type               |
 
-- `membershipId` FK removed — member is no longer tied to a specific period
-- `membershipTypeId` FK added — member is tied to a type directly
-- `joinedAt` and `resignedAt` added for history tracking
-- `stripeSessionId` removed (moved to `payment`)
+A period starts as a draft. Publishing it atomically creates obligations for
+applicable active members. Publishing never creates Stripe sessions or sends
+messages.
 
-Multiple rows per user are allowed:
+After publication, membership type, coverage dates, amount, and currency are
+locked. Admins may extend `dueDate` or `nonPaymentActionAt`, never move them
+earlier, and each change is audited. `acceptsApplications` may be moved between
+published periods with explicit confirmation. This supports opening an upcoming
+period early without deriving behavior from the calendar.
 
-- Different types concurrently (though only one can be `active` at a time)
-- Same type if resigned and re-joined (each "chapter" is a separate row)
+New periods are pre-filled by shifting the previous period's dates. There is no
+global calendar-settings feature in this scope.
 
-**Database constraint:** A partial unique index enforces at most one active membership per user (regardless of type):
+### `member`
 
-```sql
-CREATE UNIQUE INDEX one_active_per_user
-  ON member (userId)
-  WHERE status = 'active';
-```
+| Column                     | Type                        | Notes                                                                  |
+| -------------------------- | --------------------------- | ---------------------------------------------------------------------- |
+| id                         | TEXT PK                     | Stable across resignation, rejoining, and type changes                 |
+| userId                     | TEXT FK -> user             | Null for an organization member                                        |
+| organizationName           | TEXT                        | Null for an individual member                                          |
+| status                     | ENUM                        | `awaiting_payment`, `awaiting_approval`, `active`, `ended`, `rejected` |
+| membershipTypeId           | TEXT FK -> membershipType   | Most recently board-approved type; null if never approved              |
+| pendingMembershipTypeId    | TEXT FK -> membershipType   | Type currently requested; otherwise null                               |
+| currentMembershipStartedAt | TIMESTAMPTZ                 | Start of the current or most recently ended continuous membership      |
+| applicationMotive          | TEXT                        | Latest application motive; never reused as an end reason               |
+| createdAt, updatedAt       | TIMESTAMPTZ                 | Standard timestamps                                                    |
+| CHECK                      | userId XOR organizationName | Exactly one identity form                                              |
+| PARTIAL UNIQUE             | userId                      | One stable member per individual user                                  |
 
-### `payment` (new)
+The approved type remains on an ended member for display. A paid applicant is
+not assigned the requested type before approval. During an active member's type
+change, `membershipTypeId` remains the old type and
+`pendingMembershipTypeId` contains the requested type.
 
-| Column               | Type                           | Notes                                                        |
-| -------------------- | ------------------------------ | ------------------------------------------------------------ |
-| id                   | TEXT PK                        |                                                              |
-| memberId             | TEXT FK -> member              | Which membership relationship                                |
-| membershipPeriodId   | TEXT FK -> membershipPeriod    | Which period this payment covers                             |
-| source               | ENUM                           | `imported`, `stripe`, `manual`                               |
-| paidAt               | TIMESTAMP                      | When payment was completed. **Null = checkout in progress.** |
-| stripeSessionId      | TEXT                           | Stripe checkout session ID. Null for non-Stripe.             |
-| createdAt, updatedAt | TIMESTAMP                      | Standard timestamps                                          |
-| UNIQUE               | (memberId, membershipPeriodId) | One payment per member per period                            |
+`currentMembershipStartedAt` means the latest continuous membership, not the
+first membership ever. Rejoining updates it on approval. The first join and all
+earlier intervals are retained in `membershipEvent`.
 
-The `paidAt = null` state is used during active Stripe checkout sessions. This enables the resume flow: if a user navigates away and returns, the existing Stripe session can be resumed. Stale incomplete payments (e.g., older than 24h) are cleaned up periodically.
+### `membershipEvent`
 
-## Status Transitions
+This is durable domain history. It is separate from the generic audit log,
+whose purpose is security and operational traceability and whose write failure
+must not invalidate a domain operation.
 
-### Member statuses
+| Column                | Type                           | Notes                                                    |
+| --------------------- | ------------------------------ | -------------------------------------------------------- |
+| id                    | TEXT PK                        |                                                          |
+| memberId              | TEXT FK -> member              |                                                          |
+| eventType             | ENUM                           | Typed membership transition                              |
+| effectiveAt           | TIMESTAMPTZ                    | When the change legally or inferentially took effect     |
+| recordedAt            | TIMESTAMPTZ                    | When the system recorded it                              |
+| source                | ENUM                           | `admin`, `system`, `imported`, `migration`               |
+| certainty             | ENUM                           | `confirmed` or `inferred`                                |
+| actorUserId           | TEXT FK -> user                | Nullable for migration/import                            |
+| relatedEventId        | TEXT FK -> membershipEvent     | Corrected/superseded event, when applicable              |
+| membershipFeePeriodId | TEXT FK -> membershipFeePeriod | Optional relevant period                                 |
+| data                  | JSONB                          | Event-specific, schema-validated reason and type details |
 
-| Status            | Meaning                                                                          |
-| ----------------- | -------------------------------------------------------------------------------- |
-| awaiting_payment  | New member applied, hasn't paid yet                                              |
-| awaiting_approval | New member paid, waiting for board decision (SS26)                               |
-| active            | Board-approved, ongoing membership                                               |
-| resigned          | No longer a member — voluntary (SS8 p1), non-payment (SS8 p2), or expelled (SS9) |
-| rejected          | Board rejected application, or payment failed/expired                            |
+Initial event types are:
 
-### Valid transitions
+- `application_submitted`, `application_approved`, `application_rejected`
+- `type_change_requested`, `type_changed`, `type_change_rejected`
+- `resigned_voluntarily`, `deemed_resigned_nonpayment`, `expelled`
+- `legacy_membership_started_inferred`, `legacy_resignation_inferred`,
+  `legacy_rejoin_inferred`
+- `membership_decision_corrected`
 
-```
-awaiting_payment  -> awaiting_approval  (Stripe payment succeeded)
-awaiting_payment  -> rejected           (Stripe payment failed/expired)
-awaiting_approval -> active             (board approves)
-awaiting_approval -> rejected           (board rejects)
-active            -> resigned           (admin action: voluntary, non-payment, or expulsion)
-```
+Confirmed events are append-only. Correcting a mistake appends
+`membership_decision_corrected`, references the wrong event, and updates the
+current snapshot in the same transaction. Reapplying or paying is not required
+to undo an admin entry mistake.
 
-Re-joining after resignation or rejection always creates a **new member row** with the full application flow (`awaiting_payment -> awaiting_approval -> active`). There is no transition from resigned/rejected back to active on the same row.
+Imported inferred events are replaceable derived data. An import may delete and
+rebuild those events from the complete set of imported payment evidence, but it
+must never rewrite a confirmed event.
 
-### What triggers resignation
+The member activity view combines membership events and payments. Corrected
+events may be collapsed for members and remain expandable for admins.
 
-All resignations are manual admin actions, never automatic:
+### `membershipObligation`
 
-- **Voluntary resignation (SS8 p1)** — member requests it, admin marks resigned
-- **Non-payment (SS8 p2)** — bulk admin action after board meeting, typically ~2 months after due date
-- **Expulsion (SS9)** — board decision for misconduct
+An obligation exists only when a fee has actually been issued to a member. It
+is not backfilled for historical imports.
 
-## Purchase Flows
+| Column                | Type                             | Notes                                             |
+| --------------------- | -------------------------------- | ------------------------------------------------- |
+| id                    | TEXT PK                          |                                                   |
+| memberId              | TEXT FK -> member                |                                                   |
+| membershipFeePeriodId | TEXT FK -> membershipFeePeriod   |                                                   |
+| kind                  | ENUM                             | `renewal`, `application`, or `type_change`        |
+| disposition           | ENUM                             | `required`, `waived`, or `cancelled`              |
+| dispositionReason     | TEXT                             | Required for waiver; optional for cancellation    |
+| createdAt, updatedAt  | TIMESTAMPTZ                      | Standard timestamps                               |
+| UNIQUE                | (memberId,membershipFeePeriodId) | At most one issued fee for this member and period |
 
-### Path A: New member applying (or re-joining after resignation)
+Paid/unpaid is derived from payments and is not duplicated on the obligation.
+The three useful views are therefore:
 
-1. User picks membership type on `/new` page
-2. Fills in required info (description/motive, student verification if needed)
-3. `member` row created with status `awaiting_payment`
-4. `payment` row created with `paidAt = null`, `stripeSessionId` set
-5. User redirected to Stripe checkout
-6. Stripe succeeds -> `payment.paidAt` set, member status -> `awaiting_approval`
-7. Board approves -> member status -> `active`
+- required and settled;
+- required and unsettled;
+- waived or cancelled.
 
-If Stripe fails/expires: member -> `rejected`, stale payment row cleaned up.
+Publishing a non-zero fee period for a payable type creates one `renewal`
+obligation for every currently active member of that approved type. The unique
+constraint makes publication idempotent. Free types and zero-fee periods create
+no obligations.
 
-If the user tries to apply again later: reuse an existing `awaiting_payment` member row for the same user+type rather than creating a new one. `rejected` rows are kept as historical records (rare — represents an actual board decision).
+An admin who directly activates a member of a paid type either records a full
+manual payment or explicitly waives the applicable obligation with a reason.
+The system never fabricates a payment to explain the exception.
 
-### Path B: Active member paying dues
+### `payment`
 
-1. Admin creates `membershipPeriod` for upcoming year (with Stripe price)
-2. Active members see "Payment due for [year]" in UI
-3. Member clicks pay -> `payment` row created (`paidAt = null`, `stripeSessionId` set)
-4. Stripe succeeds -> `payment.paidAt` set. **Member status unchanged, stays `active`.**
-5. If Stripe fails/expires -> stale payment row cleaned up. Member can retry.
+Each row is one real or inferred payment attempt. Retaining attempts is
+necessary for Stripe webhook idempotency and delayed payment outcomes.
 
-No member status changes. No approval needed. Just a payment.
+| Column                | Type                            | Notes                                                         |
+| --------------------- | ------------------------------- | ------------------------------------------------------------- |
+| id                    | TEXT PK                         |                                                               |
+| memberId              | TEXT FK -> member               |                                                               |
+| membershipFeePeriodId | TEXT FK -> membershipFeePeriod  | Always present                                                |
+| obligationId          | TEXT FK -> membershipObligation | Nullable only for historical imported/migrated evidence       |
+| source                | ENUM                            | `stripe`, `manual`, `imported`                                |
+| status                | ENUM                            | `pending`, `succeeded`, `failed`, `expired`                   |
+| amount                | INTEGER                         | Minor units; nullable when historical evidence lacks it       |
+| currency              | TEXT                            | Nullable when historical evidence lacks it                    |
+| paidAt                | TIMESTAMPTZ                     | Nullable when the exact historical completion time is unknown |
+| stripeSessionId       | TEXT UNIQUE                     | Nullable outside Stripe                                       |
+| stripePaymentIntentId | TEXT UNIQUE                     | Nullable outside Stripe                                       |
+| refundRequiredAt      | TIMESTAMPTZ                     | Admin must process a refund manually                          |
+| refundConfirmedAt     | TIMESTAMPTZ                     | Refund verified from Stripe or manually confirmed             |
+| stripeRefundId        | TEXT UNIQUE                     | Nullable for a non-Stripe refund                              |
+| manualRefundReference | TEXT                            | Required when a non-Stripe refund is confirmed                |
+| invalidatedAt         | TIMESTAMPTZ                     | Explicit correction of bad imported evidence                  |
+| invalidationReason    | TEXT                            | Required when invalidated                                     |
+| createdAt, updatedAt  | TIMESTAMPTZ                     | Standard timestamps                                           |
 
-### Path C: Admin manually adding a member
+A composite foreign key from
+`payment(obligationId, memberId, membershipFeePeriodId)` to the same obligation
+columns prevents payments from being attached across members or types.
 
-1. Admin creates `member` row directly with `active` or `awaiting_approval` status
-2. Optionally creates a `payment` row with `source: manual`
-3. Used for honorary members (no payment needed), cash payments, or edge cases
+Each retry creates a new payment row. Failed and expired attempts are retained,
+not deleted. Unique Stripe identifiers make webhook replay idempotent. A partial
+unique index permits at most one successful, non-refunded, non-invalidated
+payment per obligation.
 
-### Path D: Honorary / free members
+The first release accepts only full settlement. Stripe checkout uses the fee
+period amount and currency, and manual payments must match them.
 
-1. Admin creates `member` row with status `active`
-2. Membership type has `purchasable = false`, no periods with Stripe prices
-3. Never appears in "payment due" lists. No payments needed. Indefinite.
+## Lifecycle and workflows
+
+### New application
+
+1. The user selects a purchasable type, not a year.
+2. The system targets that type's single published
+   `acceptsApplications` fee period. Without one, applications are unavailable.
+3. The stable member is created or reused with the target in
+   `pendingMembershipTypeId`.
+4. For a paid period, the system creates an `application` obligation and a
+   Stripe payment attempt. A free application skips checkout.
+5. Successful payment, or submission of a free application, moves a
+   never-approved applicant to `awaiting_approval` and appends
+   `application_submitted`.
+6. Board approval moves the pending type to `membershipTypeId`, sets
+   `currentMembershipStartedAt`, changes status to `active`, and appends
+   `application_approved`.
+
+Failed or abandoned checkout leaves the applicant in `awaiting_payment`.
+Returning creates a new attempt when the old Stripe session is no longer
+usable. It does not create a rejection or a membership event.
+
+Board rejection appends `application_rejected`. A paid application is marked
+`refundRequiredAt`; an unpaid application obligation is cancelled. A
+never-approved applicant becomes `rejected`. A previously ended member returns
+to `ended`, preserving their old approved type and history.
+
+### Renewal
+
+Publishing a fee period issues obligations to the active members of its type.
+Paying one changes only the obligation's derived settlement state. The member
+remains active before, during, and after payment and requires no approval.
+
+The admin overdue preset is based on:
+
+- member status is `active`;
+- obligation disposition is `required`;
+- no successful, non-refunded, non-invalidated payment settles it;
+- the obligation belongs to the relevant published fee period; and
+- the fee period's due date has passed.
+
+It does not compare `paidAt` to `dueDate`, so an applicant who joins and pays
+after the general deadline is not mistaken for an existing non-payer.
+
+### Type change during renewal
+
+Self-service type changes are available only instead of paying for a new fee
+period. They are not a general mid-period operation.
+
+1. An active member selects another eligible, purchasable type and confirms
+   that the change requires board approval.
+2. The target type's application period gets a `type_change` obligation and is
+   paid like a new membership. A free target skips payment.
+3. After payment, `pendingMembershipTypeId` is set and
+   `type_change_requested` is appended. The old approved type and active status
+   remain unchanged.
+4. While the request is pending, the old type's obligation for the same new
+   period is excluded from reminders.
+5. Approval changes the approved type, clears the pending type, appends
+   `type_changed`, and cancels the replaced old-type obligation. It does not
+   restart `currentMembershipStartedAt`.
+6. Rejection retains the old type, clears the pending type, appends
+   `type_change_rejected`, restores the old obligation to reminder views, and
+   flags the target payment for manual refund.
+
+Once the member has already settled the new period under their old type,
+self-service type change is no longer offered. Exceptional mid-period changes
+are handled manually by an admin.
+
+### Ending and rejoining
+
+`ended` is deliberately neutral. The event records whether membership ended by
+voluntary resignation, a board decision on non-payment, or expulsion.
+
+Voluntary resignation and expulsion are individual confirmed actions. The
+non-payment action is a board-triggered bulk operation and is disabled before
+`nonPaymentActionAt`; it cannot be bypassed with a warning.
+
+The bulk transaction:
+
+1. validates that every selected member is still active and still unpaid;
+2. updates each snapshot to `ended`;
+3. appends one confirmed `deemed_resigned_nonpayment` event per member; and
+4. retains the unpaid obligation as historical evidence.
+
+Notices are sent after the transaction. Delivery success or failure is recorded
+against the action, failed notices can be retried, and delivery failure never
+undoes the board decision.
+
+Rejoining uses the same stable member and the full application flow. Approval
+sets a new `currentMembershipStartedAt`; older intervals remain in events.
+
+### Overdue rights and QR verification
+
+There is no `payment_overdue` membership status. Before a confirmed ending
+action, an overdue member is legally active and remains valid in membership and
+QR checks.
+
+Admin views and QR scans may show a separate fee state:
+
+- Paid
+- Overdue
+- Not due
+- No fee
+- No obligation
+
+That information does not change access authorization.
+
+### Manual refunds
+
+The application never initiates a Stripe refund in this scope.
+
+When a paid application or type change is rejected, it sets
+`refundRequiredAt`. An admin refunds it in the Stripe Dashboard and then uses
+“Verify refund”; the server fetches Stripe's state and stores
+`refundConfirmedAt` and `stripeRefundId`. A non-Stripe refund may be confirmed
+manually with a required reference.
+
+A confirmed refund stops the payment from settling its obligation. It never
+automatically changes legal membership.
+
+### Reminders
+
+The first renewal cycle uses an admin-triggered workflow:
+
+1. Open the preset due/overdue list.
+2. Review recipients.
+3. Send a bulk reminder.
+4. Record the delivery result and last message.
+
+Schedulers, recurring reminders, and Stripe-generated invoices remain out of
+scope.
+
+### Imported uncertainty and corrections
+
+Member-facing UI shows an “imported information may be inaccurate” notice,
+including the association's contact details, only while the current snapshot
+depends on inferred legacy events. Inferred history retains a visible marker.
+
+A later confirmed event establishes authoritative current state and removes the
+current warning. Historical inferred events remain labelled. Member UI may
+collapse corrected events; admin history can expand them.
 
 ## Import Logic
 
@@ -307,29 +534,6 @@ In a single migration:
 - Spot-check specific known users
 
 This is a one-shot migration with no intermediate state. Old columns are dropped in the same migration after data is moved.
-
-## Admin Actions
-
-### Individual actions
-
-| Action         | Status change                                  | Notes                                          |
-| -------------- | ---------------------------------------------- | ---------------------------------------------- |
-| Approve member | awaiting_approval -> active                    | Board decision                                 |
-| Reject member  | awaiting_payment/awaiting_approval -> rejected | Board decision                                 |
-| Mark resigned  | active -> resigned                             | Sets resignedAt, records reason in description |
-| Create member  | -> active or awaiting_approval                 | Manual add (honorary, cash payment, etc.)      |
-
-### Bulk actions
-
-| Action                      | Notes                                                                                       |
-| --------------------------- | ------------------------------------------------------------------------------------------- |
-| Bulk approve                | Approve multiple awaiting_approval members at once                                          |
-| Bulk resign for non-payment | Mark multiple active members as resigned. Used after board meeting ~2 months past due date. |
-
-### Removed
-
-- **Auto-approval** — removed entirely. Active members don't need approval to pay dues. New/re-joining members always go through board approval.
-- **Reactivate** — removed. Re-joining creates a new member row instead.
 
 ## Test Plan
 

--- a/docs/superpowers/specs/2026-04-03-membership-model-redesign.md
+++ b/docs/superpowers/specs/2026-04-03-membership-model-redesign.md
@@ -111,22 +111,22 @@ particular period by publishing a zero-fee period.
 This replaces the misleading `membershipPeriod` name. It describes a fee and
 application target, not the duration of legal membership.
 
-| Column               | Type                         | Notes                                                 |
-| -------------------- | ---------------------------- | ----------------------------------------------------- |
-| id                   | TEXT PK                      |                                                       |
-| membershipTypeId     | TEXT FK -> membershipType    |                                                       |
-| startDate            | DATE                         | Coverage/display start                                |
-| endDate              | DATE                         | Coverage/display end                                  |
-| dueDate              | DATE                         | Payment deadline                                      |
-| nonPaymentActionAt   | DATE                         | Earliest allowed bulk non-payment action              |
-| amount               | INTEGER                      | Minor currency units; zero means free for this period |
-| currency             | TEXT                         | ISO currency code                                     |
-| stripePriceId        | TEXT                         | Required before Stripe checkout, otherwise nullable   |
-| publishedAt          | TIMESTAMPTZ                  | Null while draft                                      |
-| acceptsApplications  | BOOLEAN                      | This is the user-facing target for new applications   |
-| createdAt, updatedAt | TIMESTAMPTZ                  | Standard timestamps                                   |
-| UNIQUE               | (membershipTypeId,startDate) | One period per type and start date                    |
-| PARTIAL UNIQUE       | membershipTypeId             | At most one application target per type               |
+| Column               | Type                         | Notes                                               |
+| -------------------- | ---------------------------- | --------------------------------------------------- |
+| id                   | TEXT PK                      |                                                     |
+| membershipTypeId     | TEXT FK -> membershipType    |                                                     |
+| startDate            | DATE                         | Coverage/display start                              |
+| endDate              | DATE                         | Coverage/display end                                |
+| dueDate              | DATE                         | Payment deadline                                    |
+| nonPaymentActionAt   | DATE                         | Earliest allowed bulk non-payment action            |
+| amount               | INTEGER                      | Minor units; nullable for draft/unknown legacy data |
+| currency             | TEXT                         | ISO code; nullable for draft/unknown legacy data    |
+| stripePriceId        | TEXT                         | Required before Stripe checkout, otherwise nullable |
+| publishedAt          | TIMESTAMPTZ                  | Null while draft                                    |
+| acceptsApplications  | BOOLEAN                      | This is the user-facing target for new applications |
+| createdAt, updatedAt | TIMESTAMPTZ                  | Standard timestamps                                 |
+| UNIQUE               | (membershipTypeId,startDate) | One period per type and start date                  |
+| PARTIAL UNIQUE       | membershipTypeId             | At most one application target per type             |
 
 A period starts as a draft. Publishing it atomically creates obligations for
 applicable active members. Publishing never creates Stripe sessions or sends
@@ -192,7 +192,7 @@ Initial event types are:
 - `type_change_requested`, `type_changed`, `type_change_rejected`
 - `resigned_voluntarily`, `deemed_resigned_nonpayment`, `expelled`
 - `legacy_membership_started_inferred`, `legacy_resignation_inferred`,
-  `legacy_rejoin_inferred`
+  `legacy_rejoin_inferred`, `legacy_type_changed_inferred`
 - `membership_decision_corrected`
 
 Confirmed events are append-only. Correcting a mistake appends
@@ -420,120 +420,263 @@ A later confirmed event establishes authoritative current state and removes the
 current warning. Historical inferred events remain labelled. Member UI may
 collapse corrected events; admin history can expand them.
 
-## Import Logic
+## Legacy CSV import
 
-### CSV format
+### Import lifecycle
+
+Each installation has a nullable `membershipDataLiveAt` timestamp.
+
+- **Import mode:** while it is null, admins may repeatedly import historical
+  data and rebuild inferred history.
+- **Finalize and go live:** the admin reviews a final preview and explicitly
+  establishes the live boundary.
+- **Live mode:** later imports may add history only for fee periods beginning
+  before the boundary. Rows for periods beginning on or after it are rejected.
+
+Stripe checkout is unavailable in import mode. Publishing or opening the first
+live fee period prompts the admin to finalize imports and sets
+`membershipDataLiveAt` in the same transaction. The first Stripe action never
+silently changes the mode.
+
+Historical rows imported after go-live cannot create inference at or after the
+boundary and cannot override confirmed events. This makes finalization a real
+transfer from a legacy system to this system without banning legitimate late
+historical cleanup.
+
+### Input and period calendar
+
+The canonical CSV keeps the existing exact date field:
 
 ```csv
-firstNames,lastName,homeMunicipality,email,membershipTypeId,year
-Testi,Henkilö,Helsinki,testi@aalto.fi,varsinainen-jasen,2020
-Testi,Henkilö,Helsinki,testi@aalto.fi,varsinainen-jasen,2021
-Testi,Henkilö,Helsinki,testi@aalto.fi,varsinainen-jasen,2022
-Testi,Henkilö,Helsinki,testi@aalto.fi,alumnijasen,2023
+firstNames,lastName,homeMunicipality,email,membershipTypeId,membershipStartDate
+Testi,Henkilö,Helsinki,testi@aalto.fi,varsinainen-jasen,2023-08-01
+Testi,Henkilö,Helsinki,testi@aalto.fi,varsinainen-jasen,2024-08-01
+Testi,Henkilö,Helsinki,testi@aalto.fi,ulkojasen,2025-08-01
 ```
 
-The `year` column replaces the previous `membershipStartDate`. If a full date is provided, the year is extracted (backward compatible with existing kide.app exports).
+`membershipStartDate` identifies the fee period. It is not treated as a payment
+timestamp or a board approval date. A legacy year-only variant may be accepted
+only when the import supplies the month/day calendar used to expand it; exact
+dates are never reduced to years.
 
-### Algorithm
+An onboarding import supplies fallback period rules for dates missing from the
+database. The preview shows them, and the import audit entry stores them with
+the inference `asOf` date. Tietokilta's production fallback is:
 
-The entire import runs within a **database transaction**. The same logic supports two modes:
+- start: August 1;
+- end: July 31 of the following year;
+- due: September 30; and
+- earliest non-payment action: December 1.
 
-- **Dry run (preview)**: executes within a transaction, computes the diff, then rolls back. Returns the preview of changes to the admin for review.
-- **Commit**: executes within a transaction and commits on success.
+The importer creates missing historical `membershipFeePeriod` rows for the
+expected sequence between the earliest imported period and `asOf`, including
+empty periods needed to recognize a gap. These historical periods remain
+unpublished and never create obligations. If the import cannot establish an
+expected period sequence, it preserves payments but reports that lifecycle
+inference is unavailable.
 
-Steps:
+Historical fee amount and currency may be null when the source data does not
+contain them. Current drafts must have amount and currency before publication.
 
-1. **Parse and validate** all CSV rows
-2. **Find or create users** by email (latest row wins for profile fields, same as current)
-3. **Find or create `membershipPeriod` rows** by (membershipTypeId, year) — dates derived from hardcoded organization defaults (period start: Aug 1, period end: Jul 31, due date: Sept 30)
-4. **Find or create `payment` rows** with `source: imported` for each (user, period) pair
-5. **Re-derive member rows** for each affected (user, membershipType) pair:
+### Parse and identity rules
 
-#### Member row re-derivation (step 5)
+The import first parses and validates the complete file. Any row-level error
+prevents commit.
 
-For each affected (user, membershipType):
+1. Normalize and match individual users by email.
+2. Reject organization-member CSV rows; existing organization members are
+   preserved by production migration and managed manually.
+3. Create or reuse one stable `member` per user.
+4. For an untouched imported placeholder account, profile fields come from the
+   row with the greatest `membershipStartDate`.
+5. An older import never overwrites a newer imported profile.
+6. A verified, activated, or user-edited profile is never overwritten.
+7. Conflicting profile rows for the same email and exact date are an error.
+8. Different emails remain different users. Suspected duplicates are reported;
+   user merging is outside this RFC.
 
-1. **Collect** all imported payments (where `source = imported`), sorted by period start year
-2. **Delete** all existing member rows that have **only** `source: imported` payments (protect system-created rows)
-3. **Detect continuous chains**: consecutive years with no gap form one chain
-   - Example: 2020, 2021, 2022 = one chain
-   - Example: 2020, 2021, [gap], 2024, 2025 = two chains
-4. **Create** a new `member` row for each chain:
-   - `joinedAt` = startDate of the first year's period
-   - If the chain covers the current period (i.e., today falls within the last year's period endDate or later — the member has not had a gap): `status = active`, `resignedAt = null`
-   - If the chain does not cover the current period: `status = resigned`, `resignedAt` = endDate of the last year's period
-5. **Link payments** to their respective member rows
+### Additive payment evidence
 
-This re-derivation approach is simpler than incremental merging: delete imported member rows, re-create from scratch based on all known imported payments. Since it runs in a transaction, no data is lost on failure.
+Each unique `(member, membership type, fee period)` row adds one successful
+`source = imported` payment without an obligation. `paidAt`, amount, and
+currency remain null unless the source actually supplies them.
 
-#### Conflict detection
+The importer is additive:
 
-Before deleting an imported-only member row, compare its current status with what the payment chain would derive. If they differ (e.g., an admin manually resigned an imported member, but payments say they should be active), the import **blocks with an error** listing the conflicting users. The admin or IT resolves the conflict manually before re-importing. This prevents the import from silently overwriting manual admin actions.
+- importing the same row again is a no-op;
+- file order and import order do not affect the final result;
+- absence from a later CSV never removes earlier evidence;
+- a valid existing Stripe or manual payment for the same member and period
+  means the imported row is skipped and reported as already covered; and
+- invalid imported evidence is retained with `invalidatedAt` and a reason.
+  Re-importing it remains a no-op until an admin explicitly restores it.
 
-#### Mixed source protection
+Duplicate legacy rows for the same person, type, and period are collapsed into
+one imported payment and listed in the preview. Without a source transaction
+identifier they do not prove that two payments occurred.
 
-Member rows that have **any** `source: stripe` or `source: manual` payment are never deleted or modified by import. Import creates separate member rows for imported data. This ensures production data created through the live system is never altered by imports.
+No historical obligations are fabricated. Fee periods, imported payment
+evidence, and inferred membership events are sufficient to represent the
+available history.
 
-#### Type transitions
+### Inference algorithm
 
-If the same user has varsinainen-jasen for 2020-2022 and alumnijasen for 2023-2025, these are two separate member rows (different types). The varsinainen row gets `status: resigned` with `resignedAt` at the end of the 2022 period.
+After adding evidence, the importer recomputes only replaceable inferred events
+for affected members. It never deletes a member, confirmed event, payment,
+obligation, or live field in order to rebuild history.
 
-### Order independence
+For each affected member:
 
-The re-derivation step rebuilds the complete picture on every import run. This guarantees convergence regardless of import order:
+1. Load all non-invalidated imported payments, relevant successful live
+   payments, historical fee periods, and confirmed membership events.
+2. Remove the member's previous imported/migration events with
+   `certainty = inferred` before the live boundary, or all such events while
+   still in import mode.
+3. Sort evidence by exact period dates, independent of CSV and import order.
+4. The first legacy payment infers a membership start at the period start unless
+   a confirmed event already establishes a different state.
+5. Consecutive paid periods add payments only. They are not membership renewal
+   events.
+6. For a missing expected period, infer `legacy_resignation_inferred` at that
+   period's `nonPaymentActionAt` only when `asOf` has reached the date.
+7. A later payment after an inferred end adds `legacy_rejoin_inferred` at the
+   later period's start.
+8. A sequential change to a different type adds an inferred type-change event
+   while keeping the continuous membership. Payment evidence for mutually
+   exclusive types in the same or overlapping period is ambiguous: preserve
+   both payments, report the conflict, and infer no transition from them.
+9. Replay the combined chronological timeline into the current snapshot,
+   ignoring inferred transitions wherever they conflict with confirmed state.
 
-| Import order     | Final state                                |
-| ---------------- | ------------------------------------------ |
-| 2023, 2024, 2025 | 1 member (joined 2023, active), 3 payments |
-| 2025, 2023, 2024 | same                                       |
-| 2024, 2025, 2023 | same                                       |
+The December 1 Tietokilta fallback is explicitly an inference based on recent
+bulk-resignation practice. It does not claim that the board made a recorded
+decision on that date. A member whose latest missing period has a future action
+date remains inferred active. Once the live boundary is established, merely
+passing a deadline never creates a new event; only a real board action can end
+membership for a live obligation.
 
-Gap-filling across separate imports:
+If a later additive import fills a historical gap, the inferred end and rejoin
+events disappear on rebuild. Member UI may collapse the correction, while admin
+history and the import audit retain what happened.
 
-| Import sequence               | Final state                                            |
-| ----------------------------- | ------------------------------------------------------ |
-| First: 2020, 2021, 2024, 2025 | 2 members: (2020-2021, resigned) + (2024-2025, active) |
-| Then: 2022, 2023              | 1 member: (2020-2025, active), 6 payments              |
+### Conflicts and preview
 
-### Source derivation for existing production data
+Normal admin activity never blocks an import. A confirmed voluntary
+resignation, expulsion, correction, or type change simply takes precedence;
+conflicting imported inference is skipped and shown in the preview.
 
-Existing data can be classified retroactively during migration:
+Manual review is required only when the data cannot satisfy a core invariant,
+including:
 
-- **Payments**: no `stripeSessionId` -> `source: imported`; has `stripeSessionId` -> `source: stripe`
-- **Users**: no verified email + no `lastActiveAt` -> imported placeholder user
+- overlapping mutually exclusive types with no authoritative current type;
+- two conflicting profile values for the same identity and exact date; or
+- a row whose type or period cannot be mapped.
 
-For future imports (including by other guilds), the import flow explicitly sets `source: imported` on all created records.
+The preview reports created users, periods, payments, and inferred events;
+collapsed duplicates; protected live data; ambiguities; and the resulting
+current-state counts. Dry run executes the same code in a transaction and rolls
+it back.
 
-## Production Data Migration
+### Convergence examples
 
-### Step 1: Schema changes
+All import sequences below converge after the inferred events are rebuilt:
 
-In a single migration:
+| Import sequence                            | Final evidence and inferred history                                       |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| 2023, 2024, 2025 in any order              | One stable member, three payments, one continuous membership              |
+| 2020, 2021, 2024, 2025                     | Four payments, inferred end at the 2022 action date, rejoin in 2024       |
+| Previous row set, then 2022 and 2023       | Six payments; the inferred end and rejoin disappear                       |
+| 2025 Stripe payment, then 2020–2025 import | One stable member; Stripe evidence is retained and duplicate 2025 skipped |
+| Confirmed resignation, then older import   | Payment history is added; confirmed current state remains unchanged       |
 
-1. Rename `membership` table to `membershipPeriod`
-2. Add `dueDate` column to `membershipPeriod` (set to September 30 of start year for Tietokilta)
-3. Move `requiresStudentVerification` from `membershipPeriod` to `membershipType`
-4. Restructure `member` table: add `membershipTypeId`, `joinedAt`, `resignedAt`; drop `membershipId` after data migration
-5. Create `payment` table
+## Production migration
 
-### Step 2: Data migration
+### Deployment shape
 
-1. For each existing `member` row, create a `payment` row:
-   - `membershipPeriodId` = existing `membershipId`
-   - `source` = `imported` if no `stripeSessionId`, `stripe` otherwise
-   - `paidAt` = existing `createdAt` (best available approximation)
-   - `stripeSessionId` = copied from existing member row
+Review is split into small schema, migration, workflow, and test commits. The
+production cutover itself is one transactional Drizzle schema-and-data
+migration, run with writes briefly stopped. There is no dual-write period and
+no retained compatibility tables. A database snapshot is the rollback source.
 
-2. Run the same re-derivation algorithm as import (step 5 above) to derive the new member rows from the complete set of payments per (user, membershipType).
+The same migration also runs on fresh installations. It sets
+`membershipDataLiveAt` only when legacy member rows actually exist. An empty new
+installation remains in import mode until its admin finalizes onboarding.
 
-### Step 3: Validate
+### Evidence classification
 
-- Verify total payment count matches old member row count
-- Verify every user's membership history is preserved
-- Verify active members are correctly identified
-- Spot-check specific known users
+Migration must not turn every old row into a paid payment. In particular,
+`stripeSessionId` proves that checkout was created, not that it succeeded.
 
-This is a one-shot migration with no intermediate state. Old columns are dropped in the same migration after data is moved.
+The migration uses this evidence in descending authority:
+
+1. Existing audit actions create confirmed board/admin events.
+2. `awaiting_approval` proves that the application payment completed.
+3. For a payable type, `active` or an old status representing previously active
+   membership is evidence of a completed purchase. A Stripe session makes its
+   payment source `stripe`; otherwise legacy period-shaped data becomes
+   `imported`. Free types establish membership evidence without a payment.
+4. An old imported active/ended period row may create a successful imported
+   payment with unknown `paidAt`, amount, and currency. Its lifecycle events
+   remain inferred unless an audit action confirms them.
+5. `awaiting_payment` proves only an attempted checkout. It becomes a pending or
+   expired payment attempt and never a successful payment.
+6. `rejected` is ambiguous. Audit history may prove a paid board rejection; if
+   it does not, preserve the rejection without inventing a successful payment
+   and list it in the rehearsal warnings.
+
+The migration never copies `member.createdAt` into `payment.paidAt`. Unknown is
+represented as null.
+
+### Transaction steps
+
+Within one migration transaction:
+
+1. Create the event, obligation, and payment structures and add the new member,
+   type, fee-period, and onboarding fields.
+2. Convert old period timestamps to `DATE` in the association timezone. For
+   Tietokilta this is `AT TIME ZONE 'Europe/Helsinki'` before the date cast, so
+   local midnight does not become the previous UTC date.
+3. Backfill Tietokilta historical due and inference dates using September 30 and
+   December 1. Mark them as migration assumptions.
+4. Collapse old per-period rows into one stable member per user or organization.
+   Preserve a deterministic existing identifier and rewire every referencing
+   row before removing duplicates.
+5. Create payments and confirmed/inferred membership events according to the
+   evidence rules above. Do not create historical obligations.
+6. Replay events to materialize `status`, approved/pending type, and
+   `currentMembershipStartedAt`.
+7. Preserve all existing organization members without attempting CSV-style
+   inference.
+8. Validate database invariants and expected classifications.
+9. Set `membershipDataLiveAt` because this installation contained live legacy
+   data, then remove obsolete period-shaped columns and rows.
+
+Any invariant failure aborts the whole transaction. Delayed Stripe webhooks
+remain safe because old session identifiers are retained on payment attempts
+rather than deleted.
+
+### Local rehearsal against production
+
+Before deployment, export a production snapshot and run the exact Drizzle
+migration against local copies. The rehearsal helper is development-only; it is
+not a deployed table or application feature.
+
+Its report includes:
+
+- before/after counts by old and new status;
+- classification counts for Stripe, imported, pending, and ambiguous payments;
+- stable-member collapses and reference rewrites;
+- inferred starts, ends, rejoins, and type changes;
+- ambiguous rejected rows and overlapping types;
+- timezone/date conversions;
+- current snapshots that still depend on inference;
+- orphan, uniqueness, and cross-type invariant checks; and
+- a comparison of two fresh-snapshot rehearsal runs to prove determinism.
+
+Detailed rows and personal data stay local. Sanitized totals and explained
+warnings may be added to the pull request. We do not have the original kide.app
+CSV exports, so importer coverage uses synthetic fixtures; the production
+snapshot validates the migration path.
 
 ## Test Plan
 

--- a/docs/superpowers/specs/2026-04-03-membership-model-redesign.md
+++ b/docs/superpowers/specs/2026-04-03-membership-model-redesign.md
@@ -1,963 +1,178 @@
-# Membership Model Redesign
+# RFC: Indefinite Membership and Yearly Fees
 
-## Decision summary
+> This PR is for design review and comments. It is not intended to be merged.
+> Implementation will happen in separate PRs after the design is agreed.
 
-Legal membership is indefinite. A yearly fee is an obligation attached to an
-already-existing membership, not a new membership chapter.
+## Problem
 
-The redesigned model therefore separates five facts:
+The current model inherited from kide.app treats every yearly payment as a new,
+time-limited membership. That is convenient for selling memberships, but it
+does not match how Finnish association membership works.
 
-1. `member` is the current legal snapshot for one person or organization.
-2. `membershipEvent` is the durable history of legal membership decisions.
-3. `membershipFeePeriod` defines one type's fee and deadlines for a period.
-4. `membershipObligation` records that a particular member was issued that fee.
-5. `payment` records money and payment attempts.
+Membership continues until the member resigns or the board ends it. A yearly
+fee is a separate obligation. The current model confuses those facts, which
+creates false membership histories, unnecessary renewal approvals, and unclear
+handling of unpaid members.
 
-This is deliberately not full event sourcing. Current lists read the `member`
-snapshot; history reads immutable domain events. Payments remain their own
-financial records.
+## Proposed model
 
-## Context
+The proposal separates five facts:
 
-### Problem
+- **Member:** one stable record for the person's current legal membership.
+- **Membership event:** durable history of joining, approval, type changes,
+  resignation, expulsion, non-payment decisions, and corrections.
+- **Fee period:** the yearly fee, due date, and earliest non-payment action date
+  for one membership type.
+- **Obligation:** records that a particular member was actually issued that
+  fee.
+- **Payment:** records Stripe, manual, and imported payment attempts.
 
-The current model copies kide.app: a membership is a product with start and end
-times that a user buys each year. This creates false membership chapters,
-displays old periods as resignations, and sends renewals through an application
-approval flow.
+This is not full event sourcing. The member row remains the simple current
+snapshot; events preserve history.
 
-That model does not match Tietokilta's rules:
+## Decisions
 
-- Membership continues until it is ended under sections 8 or 9.
-- The annual meeting sets fees by membership category under section 7.
-- The board may deem a member resigned after the fee has been overdue for two
-  months, but non-payment does not itself end membership.
-- A new member requires the board decision described in section 25(4).
+### Membership does not expire with a fee period
 
-Other associations have different fee categories and deadlines, but the same
-separation between legal membership and fees is broadly useful.
+An active member remains active when a due date passes. There is no
+`payment_overdue` membership status and no automatic resignation.
 
-### Current state
+Admins instead get a preset list of active members with an unpaid current
+obligation. They can send reminders and, after the period's
+`nonPaymentActionAt`, record the board's bulk decision to deem selected members
+resigned. QR verification and other membership rights remain valid until that
+decision.
 
-The production database contains roughly 3,000 old period-shaped member rows,
-including data imported from kide.app and rows created by the live Stripe flow.
-Their history cannot be reconstructed perfectly. Migration must preserve the
-available evidence, identify inference as inference, and establish a correct
-model going forward.
+The final membership status is neutral (`ended`). The event records whether the
+reason was voluntary resignation, non-payment, or expulsion.
 
-### Goals
+### One stable member record, with durable history
 
-1. Represent indefinite membership and mutually exclusive membership types.
-2. Keep renewals as payments without a new board approval.
-3. Give the board an explicit, safe non-payment workflow.
-4. Preserve legal history without treating an audit log as domain data.
-5. Support deterministic, additive, order-independent legacy imports.
-6. Migrate the current production database in one rehearsed transaction.
+Resigning, rejoining, and changing type do not create new member records. A
+member has at most one approved membership type at a time.
 
-### Non-goals
+Membership events distinguish when a decision took effect from when it was
+recorded. Confirmed events are immutable; correcting an admin mistake appends a
+correction rather than rewriting history.
 
-- Automatic reminders or automatic membership status changes
-- Stripe Invoicing or automatic Stripe refunds
-- Partial payments, installments, discounts, or moving credit between periods
-- Individual deadline extensions in the first release
-- Importing organization members from CSV
-- Custom member fields
-- Bulk correction tooling for confirmed board decisions
-- Multi-tenancy
+The existing audit log remains an operational/security log. It is not the
+authoritative membership history.
 
-## Invariants
+### Obligations say who owes a fee
 
-These rules are the correctness boundary for the implementation:
-
-1. One person or organization has one stable `member` aggregate.
-2. A member has at most one approved membership type at a time.
-3. Paying a renewal never approves, renews, or ends legal membership.
-4. No failed, expired, or abandoned checkout rejects an application.
-5. Only a confirmed board/admin action changes an active membership to `ended`.
-6. Overdue members retain all membership rights until that action, including QR
-   verification and member-only access.
-7. Imported inference may be rebuilt. Confirmed events are immutable and may
-   only be corrected by a new event.
-8. A fee is due only when a `required` obligation exists. Lack of a payment row
-   alone does not create a debt.
-9. A required obligation is settled only by a successful, non-refunded,
-   non-invalidated payment for that obligation.
-10. Live Stripe/manual activity and confirmed membership events always take
-    precedence over imported inference.
-11. A paid application or type change cannot be approved until its target
-    obligation is settled. A direct admin activation is the separate,
-    explicitly waived exception.
-
-Membership decisions lock the stable member row and append the event plus
-snapshot update in one transaction. Payment state changes and non-payment
-actions lock the relevant obligation before deciding whether it is settled.
-Using the same member-then-obligation lock order prevents a payment/bulk-action
-race from ending a member who just paid.
-
-## Data model
-
-Names below use application-level camel case. Database migrations continue to
-use the project's snake-case convention.
-
-### `membershipType`
-
-| Column                      | Type                    | Notes                                                 |
-| --------------------------- | ----------------------- | ----------------------------------------------------- |
-| id                          | TEXT PK                 | Stable identifier, for example `varsinainen-jasen`    |
-| name                        | JSONB (LocalizedString) | Display name                                          |
-| description                 | JSONB (LocalizedString) | Optional description                                  |
-| purchasable                 | BOOLEAN                 | Users may select this type themselves                 |
-| requiresPayment             | BOOLEAN                 | Members of this type normally receive annual fee dues |
-| requiresStudentVerification | BOOLEAN                 | Requires the configured student identity verification |
-| createdAt, updatedAt        | TIMESTAMPTZ             | Standard timestamps                                   |
-
-`purchasable` and `requiresPayment` are independent. For example, an honorary
-type may be neither purchasable nor payable. A type may also be free for a
-particular period by publishing a zero-fee period.
-
-### `membershipFeePeriod`
-
-This replaces the misleading `membershipPeriod` name. It describes a fee and
-application target, not the duration of legal membership.
-
-| Column               | Type                         | Notes                                               |
-| -------------------- | ---------------------------- | --------------------------------------------------- |
-| id                   | TEXT PK                      |                                                     |
-| membershipTypeId     | TEXT FK -> membershipType    |                                                     |
-| startDate            | DATE                         | Coverage/display start                              |
-| endDate              | DATE                         | Coverage/display end                                |
-| dueDate              | DATE                         | Payment deadline                                    |
-| nonPaymentActionAt   | DATE                         | Earliest allowed bulk non-payment action            |
-| amount               | INTEGER                      | Minor units; nullable for draft/unknown legacy data |
-| currency             | TEXT                         | ISO code; nullable for draft/unknown legacy data    |
-| stripePriceId        | TEXT                         | Required before Stripe checkout, otherwise nullable |
-| publishedAt          | TIMESTAMPTZ                  | Null while draft                                    |
-| acceptsApplications  | BOOLEAN                      | This is the user-facing target for new applications |
-| createdAt, updatedAt | TIMESTAMPTZ                  | Standard timestamps                                 |
-| UNIQUE               | (membershipTypeId,startDate) | One period per type and start date                  |
-| PARTIAL UNIQUE       | membershipTypeId             | At most one application target per type             |
-
-A period starts as a draft. Publishing it atomically creates obligations for
-applicable active members. Publishing never creates Stripe sessions or sends
+Publishing a fee period creates one obligation for each applicable active
+member. Publishing is idempotent and does not create Stripe checkouts or send
 messages.
 
-After publication, membership type, coverage dates, amount, and currency are
-locked. Admins may extend `dueDate` or `nonPaymentActionAt`, never move them
-earlier, and each change is audited. `acceptsApplications` may be moved between
-published periods with explicit confirmation. This supports opening an upcoming
-period early without deriving behavior from the calendar.
-
-New periods are pre-filled by shifting the previous period's dates. There is no
-global calendar-settings feature in this scope.
-
-### `member`
-
-| Column                     | Type                        | Notes                                                                  |
-| -------------------------- | --------------------------- | ---------------------------------------------------------------------- |
-| id                         | TEXT PK                     | Stable across resignation, rejoining, and type changes                 |
-| userId                     | TEXT FK -> user             | Null for an organization member                                        |
-| organizationName           | TEXT                        | Null for an individual member                                          |
-| status                     | ENUM                        | `awaiting_payment`, `awaiting_approval`, `active`, `ended`, `rejected` |
-| membershipTypeId           | TEXT FK -> membershipType   | Most recently board-approved type; null if never approved              |
-| pendingMembershipTypeId    | TEXT FK -> membershipType   | Type currently requested; otherwise null                               |
-| currentMembershipStartedAt | TIMESTAMPTZ                 | Start of the current or most recently ended continuous membership      |
-| applicationMotive          | TEXT                        | Latest application motive; never reused as an end reason               |
-| createdAt, updatedAt       | TIMESTAMPTZ                 | Standard timestamps                                                    |
-| CHECK                      | userId XOR organizationName | Exactly one identity form                                              |
-| PARTIAL UNIQUE             | userId                      | One stable member per individual user                                  |
-
-The approved type remains on an ended member for display. A paid applicant is
-not assigned the requested type before approval. During an active member's type
-change, `membershipTypeId` remains the old type and
-`pendingMembershipTypeId` contains the requested type.
-
-`currentMembershipStartedAt` means the latest continuous membership, not the
-first membership ever. Rejoining updates it on approval. The first join and all
-earlier intervals are retained in `membershipEvent`.
-
-### `membershipEvent`
-
-This is durable domain history. It is separate from the generic audit log,
-whose purpose is security and operational traceability and whose write failure
-must not invalidate a domain operation.
-
-| Column                | Type                           | Notes                                                    |
-| --------------------- | ------------------------------ | -------------------------------------------------------- |
-| id                    | TEXT PK                        |                                                          |
-| memberId              | TEXT FK -> member              |                                                          |
-| eventType             | ENUM                           | Typed membership transition                              |
-| effectiveAt           | TIMESTAMPTZ                    | When the change legally or inferentially took effect     |
-| recordedAt            | TIMESTAMPTZ                    | When the system recorded it                              |
-| source                | ENUM                           | `admin`, `system`, `imported`, `migration`               |
-| certainty             | ENUM                           | `confirmed` or `inferred`                                |
-| actorUserId           | TEXT FK -> user                | Nullable for migration/import                            |
-| relatedEventId        | TEXT FK -> membershipEvent     | Corrected/superseded event, when applicable              |
-| membershipFeePeriodId | TEXT FK -> membershipFeePeriod | Optional relevant period                                 |
-| data                  | JSONB                          | Event-specific, schema-validated reason and type details |
-
-Initial event types are:
-
-- `application_submitted`, `application_approved`, `application_rejected`
-- `type_change_requested`, `type_changed`, `type_change_rejected`
-- `resigned_voluntarily`, `deemed_resigned_nonpayment`, `expelled`
-- `legacy_membership_started_inferred`, `legacy_resignation_inferred`,
-  `legacy_rejoin_inferred`, `legacy_type_changed_inferred`
-- `membership_decision_corrected`
-
-Confirmed events are append-only. Correcting a mistake appends
-`membership_decision_corrected`, references the wrong event, and updates the
-current snapshot in the same transaction. Reapplying or paying is not required
-to undo an admin entry mistake.
-
-Imported inferred events are replaceable derived data. An import may delete and
-rebuild those events from the complete set of imported payment evidence, but it
-must never rewrite a confirmed event.
-
-The member activity view combines membership events and payments. Corrected
-events may be collapsed for members and remain expandable for admins.
-
-### `membershipObligation`
-
-An obligation exists only when a fee has actually been issued to a member. It
-is not backfilled for historical imports.
-
-| Column                | Type                             | Notes                                             |
-| --------------------- | -------------------------------- | ------------------------------------------------- |
-| id                    | TEXT PK                          |                                                   |
-| memberId              | TEXT FK -> member                |                                                   |
-| membershipFeePeriodId | TEXT FK -> membershipFeePeriod   |                                                   |
-| kind                  | ENUM                             | `renewal`, `application`, or `type_change`        |
-| disposition           | ENUM                             | `required`, `waived`, or `cancelled`              |
-| dispositionReason     | TEXT                             | Required for waiver; optional for cancellation    |
-| createdAt, updatedAt  | TIMESTAMPTZ                      | Standard timestamps                               |
-| UNIQUE                | (memberId,membershipFeePeriodId) | At most one issued fee for this member and period |
-
-Paid/unpaid is derived from payments and is not duplicated on the obligation.
-The three useful views are therefore:
-
-- required and settled;
-- required and unsettled;
-- waived or cancelled.
-
-Publishing a non-zero fee period for a payable type creates one `renewal`
-obligation for every currently active member of that approved type. The unique
-constraint makes publication idempotent. Free types and zero-fee periods create
-no obligations. A non-zero period cannot be published for a type whose
-`requiresPayment` is false.
-
-An admin who directly activates a member of a paid type either records a full
-manual payment or explicitly waives the applicable obligation with a reason.
-The system never fabricates a payment to explain the exception.
-
-### `payment`
-
-Each row is one real or inferred payment attempt. Retaining attempts is
-necessary for Stripe webhook idempotency and delayed payment outcomes.
-
-| Column                | Type                            | Notes                                                                                               |
-| --------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------- |
-| id                    | TEXT PK                         |                                                                                                     |
-| memberId              | TEXT FK -> member               |                                                                                                     |
-| membershipFeePeriodId | TEXT FK -> membershipFeePeriod  | Always present                                                                                      |
-| obligationId          | TEXT FK -> membershipObligation | Nullable only for historical imported/migrated evidence                                             |
-| source                | ENUM                            | `stripe`, `manual`, `imported`                                                                      |
-| status                | ENUM                            | `pending`, `succeeded`, `failed`, `expired`                                                         |
-| amount                | INTEGER                         | Minor units; nullable when historical evidence lacks it                                             |
-| currency              | TEXT                            | Nullable when historical evidence lacks it                                                          |
-| paidAt                | TIMESTAMPTZ                     | Nullable when the exact historical completion time is unknown                                       |
-| stripeSessionId       | TEXT UNIQUE                     | Nullable outside Stripe                                                                             |
-| stripePaymentIntentId | TEXT UNIQUE                     | Nullable outside Stripe                                                                             |
-| refundRequiredAt      | TIMESTAMPTZ                     | Admin must process a refund manually                                                                |
-| refundReason          | ENUM                            | `application_rejected`, `type_change_rejected`, `duplicate_payment`, `obsolete_obligation`, `other` |
-| refundConfirmedAt     | TIMESTAMPTZ                     | Refund verified from Stripe or manually confirmed                                                   |
-| stripeRefundId        | TEXT UNIQUE                     | Nullable for a non-Stripe refund                                                                    |
-| manualRefundReference | TEXT                            | Required when a non-Stripe refund is confirmed                                                      |
-| invalidatedAt         | TIMESTAMPTZ                     | Explicit correction of bad imported evidence                                                        |
-| invalidationReason    | TEXT                            | Required when invalidated                                                                           |
-| createdAt, updatedAt  | TIMESTAMPTZ                     | Standard timestamps                                                                                 |
-
-A composite foreign key from
-`payment(obligationId, memberId, membershipFeePeriodId)` to the same obligation
-columns prevents payments from being attached across members or types.
-
-Each retry creates a new payment row. Failed and expired attempts are retained,
-not deleted. Unique Stripe identifiers make webhook replay idempotent. A partial
-unique index permits at most one `pending` Stripe attempt per obligation; a new
-attempt requires the previous session to be confirmed unusable and marked
-failed or expired.
-
-The ledger must allow more than one successful payment because two real charges
-can occur despite checkout safeguards. The obligation is settled when at least
-one successful, non-refunded, non-invalidated payment exists. Any additional
-success is recorded, flagged with `refundReason = duplicate_payment`, and shown
-to admins for manual refund.
-
-A success arriving for an already cancelled or waived obligation is likewise
-recorded and queued with `refundReason = obsolete_obligation`.
-
-The first release accepts only full settlement. Stripe checkout uses the fee
-period amount and currency, and manual payments must match them.
-
-## Lifecycle and workflows
-
-### New application
-
-1. The user selects a purchasable type, not a year.
-2. The system targets that type's single published
-   `acceptsApplications` fee period. Without one, applications are unavailable.
-3. The stable member is created or reused with the target in
-   `pendingMembershipTypeId`.
-4. For a paid period, the system creates an `application` obligation and a
-   Stripe payment attempt. A free application skips checkout.
-5. Successful payment, or submission of a free application, moves a
-   never-approved applicant to `awaiting_approval` and appends
-   `application_submitted`.
-6. Board approval moves the pending type to `membershipTypeId`, sets
-   `currentMembershipStartedAt`, changes status to `active`, and appends
-   `application_approved`.
-
-Failed or abandoned checkout leaves the applicant in `awaiting_payment`.
-Returning creates a new attempt when the old Stripe session is no longer
-usable. It does not create a rejection or a membership event.
-
-Before payment succeeds, retry re-evaluates the type's current application
-period. If the admin moved applications to an upcoming period, the old
-obligation and checkout are cancelled/expired and the user sees the new dates
-and price before starting another attempt. A successful payment is never
-silently moved between periods.
-
-Board rejection appends `application_rejected`. A paid application is marked
-`refundRequiredAt`, and its application obligation is cancelled whether paid or
-unpaid. A never-approved applicant becomes `rejected`. A previously ended
-member returns to `ended`, preserving their old approved type and history. A
-later reapplication to the same period reopens the existing obligation instead
-of inserting a duplicate.
-
-### Renewal
-
-Publishing a fee period issues obligations to the active members of its type.
-Paying one changes only the obligation's derived settlement state. The member
-remains active before, during, and after payment and requires no approval.
-
-The admin overdue preset is based on:
-
-- member status is `active`;
-- obligation disposition is `required`;
-- no successful, non-refunded, non-invalidated payment settles it;
-- the obligation belongs to the relevant published fee period; and
-- the fee period's due date has passed.
-
-It does not compare `paidAt` to `dueDate`, so an applicant who joins and pays
-after the general deadline is not mistaken for an existing non-payer.
-
-### Type change during renewal
-
-Self-service type changes are available only instead of paying for a new fee
-period. They are not a general mid-period operation.
-
-1. An active member selects another eligible, purchasable type and confirms
-   that the change requires board approval.
-2. The target type's application period gets a `type_change` obligation and is
-   paid like a new membership. A free target skips payment.
-3. After payment, `pendingMembershipTypeId` is set and
-   `type_change_requested` is appended. The old approved type and active status
-   remain unchanged.
-4. While the request is pending, the old type's obligation for the same new
-   period is excluded from reminders.
-5. Approval changes the approved type, clears the pending type, appends
-   `type_changed`, and cancels the replaced old-type obligation. It does not
-   restart `currentMembershipStartedAt`.
-6. Rejection retains the old type, clears the pending type, appends
-   `type_change_rejected`, restores the old obligation to reminder views, and
-   cancels the target obligation. A successful target payment is flagged for
-   manual refund.
-
-Once the member has already settled the new period under their old type,
-self-service type change is no longer offered. Exceptional mid-period changes
-are handled manually by an admin.
-
-### Ending and rejoining
-
-`ended` is deliberately neutral. The event records whether membership ended by
-voluntary resignation, a board decision on non-payment, or expulsion.
-
-Voluntary resignation and expulsion are individual confirmed actions. The
-non-payment action is a board-triggered bulk operation and is disabled before
-`nonPaymentActionAt`; it cannot be bypassed with a warning.
-
-The bulk transaction:
-
-1. validates that every selected member is still active and still unpaid;
-2. updates each snapshot to `ended`;
-3. appends one confirmed `deemed_resigned_nonpayment` event per member; and
-4. retains the unpaid obligation as historical evidence.
-
-Notices are sent after the transaction. Delivery success or failure is recorded
-against the action, failed notices can be retried, and delivery failure never
-undoes the board decision.
-
-Rejoining uses the same stable member and the full application flow. Approval
-sets a new `currentMembershipStartedAt`; older intervals remain in events.
-
-### Overdue rights and QR verification
-
-There is no `payment_overdue` membership status. Before a confirmed ending
-action, an overdue member is legally active and remains valid in membership and
-QR checks.
-
-Admin views and QR scans may show a separate fee state:
-
-- Paid
-- Overdue
-- Not due
-- No fee
-- No obligation
-
-That information does not change access authorization.
-
-### Manual refunds
-
-The application never initiates a Stripe refund in this scope.
-
-When a paid application or type change is rejected, it sets
-`refundRequiredAt`. An admin refunds it in the Stripe Dashboard and then uses
-“Verify refund”; the server fetches Stripe's state and stores
-`refundConfirmedAt` and `stripeRefundId`. A non-Stripe refund may be confirmed
-manually with a required reference. Only a full refund clears the requirement;
-partial refunds are outside this release.
-
-A duplicate successful payment enters the same queue with
-`refundReason = duplicate_payment`. Recording the extra charge never displaces
-the earlier payment that already settled the obligation.
-
-A confirmed refund stops the payment from settling its obligation. It never
-automatically changes legal membership.
-
-### Reminders
-
-The first renewal cycle uses an admin-triggered workflow:
-
-1. Open the preset due/overdue list.
-2. Review recipients.
-3. Send a bulk reminder.
-4. Record the delivery result and last message.
-
-Schedulers, recurring reminders, and Stripe-generated invoices remain out of
-scope.
-
-### Imported uncertainty and corrections
-
-Member-facing UI shows an “imported information may be inaccurate” notice,
-including the association's contact details, only while the current snapshot
-depends on inferred legacy events. Inferred history retains a visible marker.
-
-A later confirmed event establishes authoritative current state and removes the
-current warning. Historical inferred events remain labelled. Member UI may
-collapse corrected events; admin history can expand them.
-
-## Legacy CSV import
-
-### Import lifecycle
-
-Each installation has a nullable `membershipDataLiveAt` timestamp.
-
-- **Import mode:** while it is null, admins may repeatedly import historical
-  data and rebuild inferred history.
-- **Finalize and go live:** the admin reviews a final preview and explicitly
-  establishes the live boundary.
-- **Live mode:** later imports may add history only for fee periods beginning
-  before the boundary. Rows for periods beginning on or after it are rejected.
-
-Stripe checkout is unavailable in import mode. Publishing or opening the first
-live fee period prompts the admin to finalize imports and sets
-`membershipDataLiveAt` in the same transaction. The first Stripe action never
-silently changes the mode.
-
-Historical rows imported after go-live cannot create inference at or after the
-boundary and cannot override confirmed events. This makes finalization a real
-transfer from a legacy system to this system without banning legitimate late
-historical cleanup.
-
-### Input and period calendar
-
-The canonical CSV keeps the existing exact date field:
-
-```csv
-firstNames,lastName,homeMunicipality,email,membershipTypeId,membershipStartDate
-Testi,Henkilö,Helsinki,testi@aalto.fi,varsinainen-jasen,2023-08-01
-Testi,Henkilö,Helsinki,testi@aalto.fi,varsinainen-jasen,2024-08-01
-Testi,Henkilö,Helsinki,testi@aalto.fi,ulkojasen,2025-08-01
-```
-
-`membershipStartDate` identifies the fee period. It is not treated as a payment
-timestamp or a board approval date. A legacy year-only variant may be accepted
-only when the import supplies the month/day calendar used to expand it; exact
-dates are never reduced to years.
-
-An onboarding import supplies fallback period rules for dates missing from the
-database. The preview shows them, and the import audit entry stores them with
-the inference `asOf` date. Tietokilta's production fallback is:
-
-- start: August 1;
-- end: July 31 of the following year;
-- due: September 30; and
-- earliest non-payment action: December 1.
-
-The importer creates missing historical `membershipFeePeriod` rows for the
-expected sequence between the earliest imported period and `asOf`, including
-empty periods needed to recognize a gap. These historical periods remain
-unpublished and never create obligations. If the import cannot establish an
-expected period sequence, it preserves payments but reports that lifecycle
-inference is unavailable.
-
-Historical fee amount and currency may be null when the source data does not
-contain them. Current drafts must have amount and currency before publication.
-
-### Parse and identity rules
-
-The import first parses and validates the complete file. Any row-level error
-prevents commit.
-
-1. Normalize and match individual users by email.
-2. Reject organization-member CSV rows; existing organization members are
-   preserved by production migration and managed manually.
-3. Create or reuse one stable `member` per user.
-4. For an untouched imported placeholder account, profile fields come from the
-   row with the greatest `membershipStartDate`.
-5. An older import never overwrites a newer imported profile.
-6. A verified, activated, or user-edited profile is never overwritten.
-7. Conflicting profile rows for the same email and exact date are an error.
-8. Different emails remain different users. Suspected duplicates are reported;
-   user merging is outside this RFC.
-
-### Additive payment evidence
-
-Each unique `(member, membership type, fee period)` row adds one successful
-`source = imported` payment without an obligation. `paidAt`, amount, and
-currency remain null unless the source actually supplies them.
-
-The importer is additive:
-
-- importing the same row again is a no-op;
-- file order and import order do not affect the final result;
-- absence from a later CSV never removes earlier evidence;
-- a valid existing Stripe or manual payment for the same member and period
-  means the imported row is skipped and reported as already covered; and
-- invalid imported evidence is retained with `invalidatedAt` and a reason.
-  Re-importing it remains a no-op until an admin explicitly restores it.
-
-Duplicate legacy rows for the same person, type, and period are collapsed into
-one imported payment and listed in the preview. Without a source transaction
-identifier they do not prove that two payments occurred.
-
-No historical obligations are fabricated. Fee periods, imported payment
-evidence, and inferred membership events are sufficient to represent the
-available history.
-
-### Inference algorithm
-
-After adding evidence, the importer recomputes only replaceable inferred events
-for affected members. It never deletes a member, confirmed event, payment,
-obligation, or live field in order to rebuild history.
-
-For each affected member:
-
-1. Load all non-invalidated imported payments, relevant successful live
-   payments, historical fee periods, and confirmed membership events.
-2. Remove the member's previous imported/migration events with
-   `certainty = inferred` before the live boundary, or all such events while
-   still in import mode.
-3. Sort evidence by exact period dates, independent of CSV and import order.
-4. The first legacy payment infers a membership start at the period start unless
-   a confirmed event already establishes a different state.
-5. Consecutive paid periods add payments only. They are not membership renewal
-   events.
-6. For a missing expected period, infer `legacy_resignation_inferred` at that
-   period's `nonPaymentActionAt` only when `asOf` has reached the date.
-7. A later payment after an inferred end adds `legacy_rejoin_inferred` at the
-   later period's start.
-8. A sequential change to a different type adds an inferred type-change event
-   while keeping the continuous membership. Payment evidence for mutually
-   exclusive types in the same or overlapping period is ambiguous: preserve
-   both payments, report the conflict, and infer no transition from them.
-9. Replay the combined chronological timeline into the current snapshot,
-   ignoring inferred transitions wherever they conflict with confirmed state.
-
-The December 1 Tietokilta fallback is explicitly an inference based on recent
-bulk-resignation practice. It does not claim that the board made a recorded
-decision on that date. A member whose latest missing period has a future action
-date remains inferred active. Once the live boundary is established, merely
-passing a deadline never creates a new event; only a real board action can end
-membership for a live obligation.
-
-If a later additive import fills a historical gap, the inferred end and rejoin
-events disappear on rebuild. Member UI may collapse the correction, while admin
-history and the import audit retain what happened.
-
-### Conflicts and preview
-
-Normal admin activity never blocks an import. A confirmed voluntary
-resignation, expulsion, correction, or type change simply takes precedence;
-conflicting imported inference is skipped and shown in the preview.
-
-Manual review is required only when the data cannot satisfy a core invariant,
-including:
-
-- overlapping mutually exclusive types with no authoritative current type;
-- two conflicting profile values for the same identity and exact date; or
-- a row whose type or period cannot be mapped.
-
-The preview reports created users, periods, payments, and inferred events;
-collapsed duplicates; protected live data; ambiguities; and the resulting
-current-state counts. Dry run executes the same code in a transaction and rolls
-it back.
-
-### Convergence examples
-
-All import sequences below converge after the inferred events are rebuilt:
-
-| Import sequence                            | Final evidence and inferred history                                       |
-| ------------------------------------------ | ------------------------------------------------------------------------- |
-| 2023, 2024, 2025 in any order              | One stable member, three payments, one continuous membership              |
-| 2020, 2021, 2024, 2025                     | Four payments, inferred end at the 2022 action date, rejoin in 2024       |
-| Previous row set, then 2022 and 2023       | Six payments; the inferred end and rejoin disappear                       |
-| 2025 Stripe payment, then 2020–2025 import | One stable member; Stripe evidence is retained and duplicate 2025 skipped |
-| Confirmed resignation, then older import   | Payment history is added; confirmed current state remains unchanged       |
+Free membership types and zero-fee periods create no obligations. An admin may
+activate a paid member without inventing a payment by explicitly waiving the
+obligation with a reason.
+
+Payment state is not duplicated on the obligation: it is paid when at least one
+successful, non-refunded payment exists.
+
+### Applications and renewals are different
+
+A new or returning applicant selects a membership type. The admin chooses which
+published fee period currently accepts applications, so an upcoming period can
+be opened early without calendar-specific rules.
+
+Paid applicants go through Stripe and then wait for board approval. Free
+applicants skip payment but still wait for approval. Failed or abandoned
+checkouts stay retryable and never become board rejections.
+
+An active member only pays their new obligation. Renewal does not change
+membership status or require approval.
+
+### Type changes happen during renewal
+
+During a new fee period, an active member may select another eligible type
+instead of renewing the old one. They pay the target fee and the change goes to
+the board. Their old type remains active until approval.
+
+Approval replaces the new-period obligation and keeps the continuous membership
+start date. Rejection keeps the old type and marks the target payment for manual
+refund. Mid-period exceptions remain admin-managed.
+
+### Refunds and reminders stay manual
+
+Refunds are rare enough that the application will not initiate them. It records
+that a refund is required; an admin refunds through Stripe and verifies the
+result in the application.
+
+The first renewal cycle uses admin-triggered bulk reminders. Scheduled or
+recurring reminders and Stripe Invoicing are out of scope.
+
+## Legacy data
+
+Historical kide.app data cannot prove every board decision. The import should
+preserve what is known without presenting guesses as legal facts.
+
+Imports are additive and order-independent:
+
+- exact source dates are preserved;
+- repeated rows are idempotent;
+- a later partial CSV never deletes earlier evidence;
+- confirmed admin decisions always override imported inference; and
+- filling a historical gap rebuilds only the inferred events.
+
+For Tietokilta, a missing historical fee is assumed to have ended membership on
+December 1 of that fee period's starting year. This reflects the recent
+November/December bulk-resignation practice, but it is explicitly labelled as
+inferred—not as a recorded board decision.
+
+Members whose current state depends on inference see a short warning and contact
+information. A later confirmed action establishes authoritative current state;
+historical inference remains visibly labelled.
+
+Other associations choose their own historical calendar during onboarding.
+Imports may be repeated until the admin explicitly finalizes import mode.
+Afterward, CSV imports may only add history from fee periods that began before
+the go-live boundary.
 
 ## Production migration
 
-### Deployment shape
+Production will use one transactional schema-and-data migration, with writes
+briefly stopped and a database snapshot as the rollback source. There is no
+dual-write period.
 
-Review is split into small schema, migration, workflow, and test commits. The
-production cutover itself is one transactional Drizzle schema-and-data
-migration, run with writes briefly stopped. There is no dual-write period and
-no retained compatibility tables. A database snapshot is the rollback source.
+Before deployment, the exact migration is rehearsed locally against a recent
+production snapshot. The report compares old and new counts, lists ambiguous
+classifications and inferred events, checks invariants, and confirms that two
+runs produce the same result.
 
-The same migration also runs on fresh installations. It sets
-`membershipDataLiveAt` only when legacy member rows actually exist. An empty new
-installation remains in import mode until its admin finalizes onboarding.
+The migration must not manufacture evidence:
 
-### Evidence classification
+- a Stripe session proves checkout started, not that it succeeded;
+- `awaiting_payment` never becomes a successful payment;
+- unknown payment dates and amounts remain unknown;
+- free members do not receive fake payments; and
+- historical obligations are not created retroactively.
 
-Migration must not turn every old row into a paid payment. In particular,
-`stripeSessionId` proves that checkout was created, not that it succeeded.
+## Scope and rollout
 
-The migration uses this evidence in descending authority:
+The August-critical work is the migration rehearsal, fee-period publication,
+obligations, renewal checkout, applications, new-period type changes, overdue
+filter, manual reminders, and imported-data warning.
 
-1. Existing audit actions create confirmed board/admin events.
-2. `awaiting_approval` proves that the application payment completed.
-3. For a payable type, `active` or an old status representing previously active
-   membership is evidence of a completed purchase. A Stripe session makes its
-   payment source `stripe`; otherwise legacy period-shaped data becomes
-   `imported`. Free types establish membership evidence without a payment.
-4. An old imported active/ended period row may create a successful imported
-   payment with unknown `paidAt`, amount, and currency. Its lifecycle events
-   remain inferred unless an audit action confirms them.
-5. `awaiting_payment` proves only an attempted checkout. It becomes a pending or
-   expired payment attempt and never a successful payment.
-6. `rejected` is ambiguous. Audit history may prove a paid board rejection; if
-   it does not, preserve the rejection without inventing a successful payment
-   and list it in the rehearsal warnings.
+The bulk non-payment decision and notice retry workflow must be ready before the
+November/December board actions, but do not need to block opening August
+payments.
 
-The migration never copies `member.createdAt` into `payment.paidAt`. Unknown is
-represented as null.
+Custom member fields, organization CSV import, automatic reminders, automatic
+refunds, individual deadline extensions, partial payments, and installments are
+outside this RFC.
 
-### Transaction steps
+Detailed schema fields, algorithms, scenario-based tests, and the cutover
+checklist are in the
+[implementation reference](./2026-04-03-membership-model-redesign-implementation.md).
 
-Within one migration transaction:
+## Review focus
 
-1. Create the event, obligation, and payment structures and add the new member,
-   type, fee-period, and onboarding fields.
-2. Convert old period timestamps to `DATE` in the association timezone. For
-   Tietokilta this is `AT TIME ZONE 'Europe/Helsinki'` before the date cast, so
-   local midnight does not become the previous UTC date.
-3. Backfill Tietokilta historical due and inference dates using September 30 and
-   December 1. Mark them as migration assumptions.
-4. Collapse old per-period rows into one stable member per user or organization.
-   Preserve a deterministic existing identifier and rewire every referencing
-   row before removing duplicates.
-5. Create payments and confirmed/inferred membership events according to the
-   evidence rules above. Do not create historical obligations.
-6. Replay events to materialize `status`, approved/pending type, and
-   `currentMembershipStartedAt`.
-7. Preserve all existing organization members without attempting CSV-style
-   inference.
-8. Validate database invariants and expected classifications.
-9. Set `membershipDataLiveAt` because this installation contained live legacy
-   data, then remove obsolete period-shaped columns and rows.
+Please focus comments on three questions:
 
-Any invariant failure aborts the whole transaction. Delayed Stripe webhooks
-remain safe because old session identifiers are retained on payment attempts
-rather than deleted.
-
-### Local rehearsal against production
-
-Before deployment, export a production snapshot and run the exact Drizzle
-migration against local copies. The rehearsal helper is development-only; it is
-not a deployed table or application feature.
-
-Its report includes:
-
-- before/after counts by old and new status;
-- classification counts for Stripe, imported, pending, and ambiguous payments;
-- stable-member collapses and reference rewrites;
-- inferred starts, ends, rejoins, and type changes;
-- ambiguous rejected rows and overlapping types;
-- timezone/date conversions;
-- current snapshots that still depend on inference;
-- orphan, uniqueness, and cross-type invariant checks; and
-- a comparison of two fresh-snapshot rehearsal runs to prove determinism.
-
-Detailed rows and personal data stay local. Sanitized totals and explained
-warnings may be added to the pull request. We do not have the original kide.app
-CSV exports, so importer coverage uses synthetic fixtures; the production
-snapshot validates the migration path.
-
-## Decision rationale
-
-| Decision                                | Rationale                                                                | Alternative not chosen                                                   |
-| --------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
-| One stable member plus domain events    | Keeps identity stable through type changes, endings, and rejoins         | Multiple “membership chapter” rows recreate the current model's problem  |
-| Explicit issued obligations             | Represents who actually owes a fee, including waivers and late additions | Inferring debt from missing payments misclassifies free and new members  |
-| No overdue membership status            | Non-payment does not alter legal membership before a board action        | Automatic status changes violate the legal and product invariant         |
-| Replaceable inferred legacy events      | Reviewing about 3,000 imported members individually is not feasible      | Treating guesses as confirmed decisions creates false legal history      |
-| Additive imports                        | Missing rows and file order cannot erase known evidence                  | Snapshot-style import makes later partial files destructive              |
-| Exact dates plus an explicit calendar   | Preserves source precision and makes legacy assumptions visible          | Reducing dates to years loses information and hides the inference policy |
-| One rehearsed production migration      | The cutover is small enough to make dual writes unnecessary              | A long compatibility phase adds code and another source of inconsistency |
-| Manual Stripe refunds with verification | Refunds are very rare, while their accounting state still matters        | Automatic refund execution adds risk without helping the renewal launch  |
-| One explicit application target         | Handles early upcoming-period sales without calendar-specific branching  | Automatically choosing by month recreates the July/August ambiguity      |
-
-## Required scenario matrix
-
-The test suite should express these as data-driven domain tests where possible.
-End-to-end tests are reserved for the user, admin, Stripe webhook, and migration
-boundaries. Dates must use a fixed clock and the Europe/Helsinki timezone.
-
-### Member identity and history
-
-| Scenario                                      | Expected result                                                               |
-| --------------------------------------------- | ----------------------------------------------------------------------------- |
-| First application is approved                 | One stable member becomes active; approved type and start time are set        |
-| Active member changes type                    | Same member ID; continuous start remains; a confirmed type event is appended  |
-| Ended member rejoins                          | Same member ID; a new continuous start is set; old interval remains in events |
-| Reapplication by an ended member is rejected  | Snapshot returns to ended; rejection remains in events                        |
-| Never-approved application is rejected        | Status becomes rejected; approved type remains null                           |
-| Voluntary resignation                         | Status becomes ended with a confirmed voluntary event                         |
-| Expulsion                                     | Status becomes ended with a confirmed expulsion event                         |
-| Admin corrects a wrong ending action          | Correction event references the old event; snapshot is restored               |
-| Member has imported and confirmed history     | Confirmed state wins; inferred events stay visibly labelled                   |
-| Same user is inserted twice concurrently      | The stable-member uniqueness constraint prevents a duplicate                  |
-| Two approved types are attempted concurrently | The transaction/constraint permits only one approved current type             |
-
-### Applications and payment attempts
-
-| Scenario                                           | Expected result                                                                |
-| -------------------------------------------------- | ------------------------------------------------------------------------------ |
-| New paid application starts checkout               | Applicant awaits payment; obligation and pending attempt exist                 |
-| Stripe checkout succeeds                           | Payment succeeds; applicant awaits approval; submission event is appended      |
-| The success webhook is replayed                    | No duplicate payment, obligation, event, or status transition                  |
-| Checkout fails or expires                          | Attempt is retained as failed/expired; applicant still awaits payment          |
-| User retries after an expired attempt              | A new attempt is created; the old attempt remains                              |
-| Application target changes before retry            | Old obligation/session closes; new dates and price require confirmation        |
-| A delayed valid webhook arrives for an old attempt | The attempt succeeds idempotently; no missing-row failure                      |
-| Delayed attempt succeeds after another payment     | Both charges are recorded; the duplicate is flagged for manual refund          |
-| Delayed payment succeeds for cancelled obligation  | Charge is recorded and flagged as obsolete for manual refund                   |
-| A second checkout starts while one is pending      | Existing usable session is resumed, or the new attempt is rejected             |
-| User returns while a session is still reusable     | Existing pending session may be resumed                                        |
-| Free purchasable type is submitted                 | No payment or obligation; applicant proceeds to board approval                 |
-| Board approves a paid application                  | Member becomes active; payment is unchanged                                    |
-| Board tries to approve before required payment     | Approval is rejected                                                           |
-| Board rejects a paid application                   | Member is rejected/returned to ended; obligation is cancelled; refund required |
-| Admin verifies the Stripe refund                   | Refund identifiers are stored and payment no longer settles the obligation     |
-| Admin confirms a non-Stripe refund                 | A manual reference is required                                                 |
-| Applicant pays after the general due date          | Approval may proceed; they never appear as an existing overdue member          |
-| Payment member/period mismatches its obligation    | Composite foreign key rejects the write                                        |
-
-### Fee periods and obligations
-
-| Scenario                                               | Expected result                                                    |
-| ------------------------------------------------------ | ------------------------------------------------------------------ |
-| Draft period is saved                                  | No obligation is created                                           |
-| Non-zero payable period is published                   | One renewal obligation per applicable active member                |
-| Publication is retried                                 | No duplicate obligations                                           |
-| Free membership type period is published               | No obligations                                                     |
-| Free type has a non-zero draft amount                  | Publication is rejected                                            |
-| Payable type has a zero-fee period                     | No obligations                                                     |
-| New active member is added after publication           | Admin records a full manual payment or a reasoned waiver           |
-| Admin directly activates a paid member without payment | Waived obligation is required; no fake payment                     |
-| Active member pays the renewal                         | Obligation settles; membership status and start time do not change |
-| Payment from the previous period exists                | New period's obligation remains unsettled                          |
-| Member has no issued obligation                        | They do not appear in due/overdue views                            |
-| Required obligation is refunded                        | It becomes unsettled; legal membership remains unchanged           |
-| Admin extends a deadline                               | Later date is saved and audited; all affected obligations use it   |
-| Admin tries to shorten a published deadline            | Operation is rejected                                              |
-| Admin edits published type, dates, amount, or currency | Operation is rejected                                              |
-| Partial or incorrectly sized manual payment is entered | Operation is rejected                                              |
-
-### Overdue, reminders, and ending membership
-
-| Scenario                                             | Expected result                                                               |
-| ---------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Required obligation is unpaid before due date        | Fee state is not due; member is active                                        |
-| Required obligation is unpaid after due date         | Fee state is overdue; member is still active                                  |
-| Honorary/free member                                 | Does not appear in the overdue preset                                         |
-| Obligation is waived or cancelled                    | Does not appear in the overdue preset                                         |
-| Successful payment exists                            | Does not appear in the overdue preset                                         |
-| Admin sends a reminder                               | Only reviewed eligible members are contacted; result is recorded              |
-| Scheduler time passes                                | No automatic reminder or status change occurs                                 |
-| Bulk ending is attempted before `nonPaymentActionAt` | Action is blocked                                                             |
-| Member pays between bulk preview and commit          | Member is not ended; admin sees that the row changed                          |
-| Eligible bulk action is committed                    | Member becomes ended and gets a confirmed non-payment event                   |
-| Notice delivery fails after the decision             | Ending remains committed; failed notice is visible and retryable              |
-| Ended member's old unpaid obligation is viewed       | It remains as historical unpaid evidence but not a current reminder recipient |
-| Overdue active member presents QR                    | Access remains valid; admin scan may also display “Overdue”                   |
-
-### Type changes during a new period
-
-| Scenario                                          | Expected result                                                               |
-| ------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Member selects their existing type                | Normal renewal; no board approval                                             |
-| Member selects a different eligible type          | Target obligation/payment starts; old type remains approved and active        |
-| Type-change checkout is abandoned                 | Old type and obligation remain unchanged; no pending board request            |
-| Paid type change awaits approval                  | Old obligation is suppressed from reminders; old legal type remains active    |
-| Board approves type change                        | Target type becomes approved; old obligation is cancelled; start is unchanged |
-| Board tries to approve unpaid type change         | Approval is rejected                                                          |
-| Board rejects paid type change                    | Old type/obligation remain; target obligation is cancelled; refund required   |
-| Member already paid the new period under old type | Self-service type change is unavailable; admin handles the exception          |
-| Member tries a mid-period self-service change     | Operation is unavailable                                                      |
-| Target type is free and purchasable               | Request skips checkout but still requires board approval                      |
-
-### Import identity and idempotency
-
-| Scenario                                           | Expected result                                               |
-| -------------------------------------------------- | ------------------------------------------------------------- |
-| Same CSV is imported twice                         | Second import is a no-op                                      |
-| Same rows appear in every file order               | Identical users, periods, payments, events, and snapshots     |
-| Consecutive years arrive in every import order     | One continuous inferred membership                            |
-| Later CSV omits an earlier row                     | Earlier payment evidence remains                              |
-| Duplicate row appears in one or several files      | One imported payment; duplicate warning                       |
-| Existing successful Stripe/manual payment overlaps | Imported duplicate is skipped; live payment remains           |
-| Invalidated imported row is imported again         | It stays invalidated until explicitly restored                |
-| Exact start dates are present                      | Exact dates match periods without year truncation             |
-| Year-only legacy row has a supplied calendar       | Date is expanded deterministically and assumption is audited  |
-| Year-only row has no calendar                      | Validation fails                                              |
-| Older profile row arrives last                     | It does not replace profile fields from a newer imported date |
-| Activated or user-edited account is imported       | Profile fields remain untouched                               |
-| Same email/date has conflicting profile values     | Import fails with a precise conflict                          |
-| Same person appears under different emails         | Separate users; suspected duplicate is reported               |
-| Organization row appears in CSV                    | Row is rejected as unsupported                                |
-| Dry run is requested                               | Preview equals commit result, but all writes are rolled back  |
-
-### Import inference and mixed sources
-
-| Scenario                                                  | Expected result                                                               |
-| --------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Gap action date is still in the future                    | Member remains inferred active                                                |
-| Missing period's December 1 action date has passed        | Inferred end is created with imported/migration provenance                    |
-| A later paid period follows the gap                       | Inferred rejoin is created on the later period start                          |
-| Gap is filled in a later import                           | Inferred end/rejoin disappear; payments and stable member remain              |
-| Sequential periods change membership type                 | Inferred type change; continuous start remains                                |
-| Mutually exclusive types overlap                          | Payments remain; no transition inferred; review warning                       |
-| Confirmed admin resignation differs from inferred history | Import adds payment history but confirmed current state wins                  |
-| Confirmed correction exists                               | Rebuild does not restore the corrected inference                              |
-| Import mode receives another historical file              | All affected pre-live inference is rebuilt                                    |
-| Go-live is finalized                                      | Boundary is stored; Stripe/live workflows become available                    |
-| Post-live import adds a pre-boundary period               | Historical evidence/inference may be added; confirmed state remains protected |
-| Post-live import contains a post-boundary period          | Row is rejected                                                               |
-| Fresh installation runs all Drizzle migrations            | It remains in import mode because no legacy members exist                     |
-
-### Production migration
-
-| Legacy evidence                                  | Expected migrated result                                                   |
-| ------------------------------------------------ | -------------------------------------------------------------------------- |
-| `awaiting_payment` with a Stripe session         | Non-successful retained attempt; no fabricated payment                     |
-| `awaiting_approval`                              | Successful payment evidence; paid time remains unknown when absent         |
-| Payable `active` row with a Stripe session       | Successful Stripe payment evidence                                         |
-| Payable imported active/previously-active row    | Successful imported payment evidence; lifecycle certainty remains inferred |
-| Free active member                               | Membership preserved without a fake payment                                |
-| `rejected` with no proof of completed payment    | Rejected state preserved; no success invented; rehearsal warning           |
-| Audited board decision                           | Confirmed event with separate effective and recorded timestamps            |
-| Old local-midnight period timestamp              | Correct Helsinki calendar date, without UTC off-by-one                     |
-| Several period rows for one user                 | One stable member; dependencies are rewired                                |
-| Existing organization member                     | Preserved for manual management                                            |
-| Historical rows                                  | No historical obligations are created                                      |
-| Unknown payment time/amount/currency             | Nulls remain null; `createdAt` is not substituted                          |
-| Delayed Stripe webhook after migration           | Retained session ID resolves to one attempt and updates idempotently       |
-| Migration invariant fails                        | Transaction rolls back completely                                          |
-| Two rehearsals use identical snapshot and inputs | Reports and migrated domain state are identical                            |
-| Production database contains legacy members      | `membershipDataLiveAt` is set during cutover                               |
-
-## Implementation and rollout
-
-### Known blast radius
-
-Implementation must update all consumers of the old period-shaped
-`membershipId`, including schema and fixtures, application/session creation,
-Stripe webhooks, member and admin queries, import, email/reminders, QR
-verification, history UI, end-to-end tests, and developer documentation of
-member statuses.
-
-### Reviewable implementation slices
-
-Keep code review small even though production has one cutover:
-
-1. Add schema definitions, constraints, event replay, and pure domain tests.
-2. Add the production migration, local rehearsal helper, and migration fixtures.
-3. Replace legacy CSV import with preview, additive evidence, and inference.
-4. Implement fee-period publication, obligations, renewal checkout, and Stripe
-   webhook idempotency.
-5. Migrate application, reapplication, paid type-change, and manual refund
-   workflows.
-6. Add overdue/reminder views, history/provenance UI, QR fee display, and the
-   bulk non-payment action.
-
-The Drizzle migration is merged with the code that understands the new schema;
-the smaller slices are commits and review units, not independently deployed
-database states.
-
-### August-critical path
-
-Before renewals open:
-
-1. Finish schema/domain tests and the importer/migration rehearsal.
-2. Run the exact migration against a recent production snapshot early enough to
-   fix classifications, not only immediately before deployment.
-3. Reconcile rehearsal counts and explicitly classify every warning category.
-4. Complete period publication, obligation creation, renewals, new
-   applications, and new-period type changes.
-5. Verify that the overdue preset excludes free, waived, newly joined, and paid
-   members.
-6. Complete the member-facing imported-data warning and preserve legally active
-   QR behavior.
-
-The admin-triggered reminders should be ready for the first renewal cycle. The
-bulk board action and notice-retry workflow must be ready before the
-November/December non-payment decisions, but they do not need to block opening
-August payments if their data invariants and tests already exist.
-
-### Cutover runbook
-
-1. Announce a short write pause and disable application/payment/admin writes.
-2. Take and verify a restorable production snapshot.
-3. Run the already-rehearsed transactional Drizzle migration.
-4. Run invariant queries and compare counts with the rehearsal report.
-5. Smoke-test admin lists, one member history, application targeting, Stripe
-   checkout in test mode, renewal eligibility, and QR verification.
-6. Re-enable writes and monitor Stripe webhooks, payment attempts, and errors.
-
-If migration or validation fails, the transaction rolls back and the old
-application remains in place. If a post-commit smoke test finds a blocking
-problem, stop writes, restore the snapshot, and redeploy the old application.
-
-### Production readiness gate
-
-Do not open renewals until:
-
-- the exact migration succeeds on a recent snapshot;
-- all invariant checks pass with zero orphans and zero illegal type overlaps;
-- every ambiguous classification is either accepted and documented or fixed;
-- two independent rehearsal runs converge;
-- Stripe webhook replay and delayed-webhook tests pass;
-- publication retry creates no duplicate obligations;
-- the board can obtain the exact active-and-unpaid list; and
-- backup restoration has been exercised or otherwise verified.
+1. Does the separation between legal membership, obligations, and payments
+   match how the board should operate?
+2. Is the legacy inference policy honest and practical enough without reviewing
+   every imported member?
+3. Is any essential August renewal scenario missing?


### PR DESCRIPTION
## RFC status

This PR is for design review and comments. It is not intended to be merged. Implementation will follow in separate PRs after the design is agreed.

## Proposal

Separate indefinite legal membership from yearly fees:

- One stable member record with durable membership history
- Explicit fee periods and per-member obligations
- Payments that do not renew, approve, or end membership
- Manual board action before an overdue membership ends
- Additive legacy imports with clearly labelled inference
- One rehearsed production migration

Please focus review on whether the model matches board operations, whether the legacy inference policy is acceptable, and whether an essential August renewal case is missing.

Read the concise RFC first: `docs/superpowers/specs/2026-04-03-membership-model-redesign.md`.

Detailed schema, algorithms, tests, and cutover notes: `docs/superpowers/specs/2026-04-03-membership-model-redesign-implementation.md`.
