### PR TITLE
fix: correct Finnish email and customization copy

### DIFF
--- a/src/lib/i18n/fi/index.ts
+++ b/src/lib/i18n/fi/index.ts
@@ -155,7 +155,7 @@ const fi = {
   // Emails
   emails: {
     otp: {
-      subject: "{organizationName:string} jäsen_rekisterin sisään_kirjautumiskoodi",
+      subject: "{organizationName:string}: jäsenrekisterin sisäänkirjautumiskoodi",
       body: `Kirjautumiskoodisi on: {code:string}
 
 Koodi vanhenee 10 minuutin kuluttua.
@@ -174,10 +174,10 @@ Terveisin,
 {organizationName:string}`,
     },
     membershipApproved: {
-      subject: "Tervetuloa {organizationName:string} jäseneksi!",
+      subject: "{organizationName:string}: jäsenhakemuksesi on hyväksytty",
       body: `Hei {firstName:string}!
 
-Jäsenhakemuksesi on hyväksytty. Tervetuloa {organizationName:string} jäseneksi!
+{organizationName:string} on hyväksynyt jäsenhakemuksesi. Tervetuloa jäseneksi!
 
 Jäsenyystiedot:
 - Jäsenyystyyppi: {membershipName:string}
@@ -433,8 +433,8 @@ Terveisin,
       resignation: {
         title: "Jäsenen erottaminen",
         rule: "Organisaation sääntö jäsenen erottamisesta (esim. §67)",
-        defaultReasonFi: "Oletus syy erottamiselle (FI)",
-        defaultReasonEn: "Oletus syy erottamiselle (EN)",
+        defaultReasonFi: "Oletussyy erottamiselle (FI)",
+        defaultReasonEn: "Oletussyy erottamiselle (EN)",
       },
       privacyPolicy: {
         title: "Rekisteri- ja tietosuojaseloste",


### PR DESCRIPTION
## Summary

- correct malformed Finnish compound words in the sign-in email subject
- reword membership approval email copy so customized organization names remain grammatical
- correct the Finnish `Oletussyy` labels in customization settings

## Verification

- `git diff --check`
- tests not run (copy-only changes)

## Notes

The app-customization change replaced hard-coded organization wording with a dynamic organization-name placeholder. That edit introduced literal underscores in compound words and placed the uninflected organization name in wording that required a Finnish grammatical case.
