### PR TITLE
chore: gitignore test-generated temporary csv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ project.inlang
 src/lib/paraglide
 result
 .fallow/
+
+# Test-generated files
+temp-*.csv


### PR DESCRIPTION
Gitignore the temporary files generated by e2e tests, so that those don't end up in git