### PR TITLE
fix: clarify when a new membership fee is due

### DIFF
--- a/src/lib/components/membership-card.svelte
+++ b/src/lib/components/membership-card.svelte
@@ -96,7 +96,7 @@
         variant: "secondary" as const,
         icon: Banknote,
         label: $LL.membership.status.activePaymentDue(),
-        cardClass: "border-amber-500/50 bg-amber-500/5",
+        cardClass: "border-yellow-500/50 bg-yellow-500/5",
       };
     }
 

--- a/src/lib/components/membership-card.svelte
+++ b/src/lib/components/membership-card.svelte
@@ -59,12 +59,16 @@
 
   const hasActiveMembership = $derived(memberships.some((m) => m.status === "active"));
   const isAwaitingPayment = $derived(currentMembership?.status === "awaiting_payment");
+  const isRenewalDue = $derived(
+    currentMembership?.status === "active" && currentMembership.endTime < new Date() && hasAvailableMemberships,
+  );
   const showQrButton = $derived(!!qrToken && !isAwaitingPayment && (hasActiveMembership || !!currentMembership));
 
   // Compute purchase/renew button config
   const purchaseAction = $derived.by(() => {
     if (isAwaitingPayment || !hasAvailableMemberships) return null;
     if (!currentMembership) return { label: $LL.dashboard.getFirstMembership(), variant: "default" as const };
+    if (isRenewalDue) return { label: $LL.dashboard.renewMembership(), variant: "default" as const };
     if (hasActiveMembership)
       return {
         label: $LL.dashboard.purchaseNew(),
@@ -84,6 +88,15 @@
         icon: CircleAlert,
         label: $LL.dashboard.noMembership(),
         cardClass: "border-muted",
+      };
+    }
+
+    if (isRenewalDue) {
+      return {
+        variant: "secondary" as const,
+        icon: Banknote,
+        label: $LL.membership.status.activePaymentDue(),
+        cardClass: "border-amber-500/50 bg-amber-500/5",
       };
     }
 

--- a/src/lib/components/membership-card.svelte
+++ b/src/lib/components/membership-card.svelte
@@ -59,10 +59,27 @@
 
   const hasActiveMembership = $derived(memberships.some((m) => m.status === "active"));
   const isAwaitingPayment = $derived(currentMembership?.status === "awaiting_payment");
+  let currentTime = $state(new Date());
   const isRenewalDue = $derived(
-    currentMembership?.status === "active" && currentMembership.endTime < new Date() && hasAvailableMemberships,
+    currentMembership?.status === "active" && currentMembership.endTime <= currentTime && hasAvailableMemberships,
   );
   const showQrButton = $derived(!!qrToken && !isAwaitingPayment && (hasActiveMembership || !!currentMembership));
+
+  $effect(() => {
+    const endTime = currentMembership?.endTime;
+    if (!endTime || endTime <= currentTime) return;
+
+    const remaining = endTime.getTime() - currentTime.getTime();
+    const timeout = setTimeout(
+      () => {
+        currentTime = new Date();
+      },
+      Math.min(remaining, 2 ** 31 - 1),
+    );
+    return () => {
+      clearTimeout(timeout);
+    };
+  });
 
   // Compute purchase/renew button config
   const purchaseAction = $derived.by(() => {

--- a/src/lib/components/membership-card.svelte
+++ b/src/lib/components/membership-card.svelte
@@ -18,6 +18,9 @@
   import Banknote from "@lucide/svelte/icons/banknote";
   import CreditCard from "@lucide/svelte/icons/credit-card";
 
+  // Browsers limit setTimeout delays to a signed 32-bit integer.
+  const MAX_TIMEOUT_DELAY_MS = 2_147_483_647;
+
   interface MembershipType {
     id: string;
     name: LocalizedString;
@@ -74,7 +77,7 @@
       () => {
         currentTime = new Date();
       },
-      Math.min(remaining, 2 ** 31 - 1),
+      Math.min(remaining, MAX_TIMEOUT_DELAY_MS),
     );
     return () => {
       clearTimeout(timeout);

--- a/src/lib/i18n/en/index.ts
+++ b/src/lib/i18n/en/index.ts
@@ -337,7 +337,7 @@ Best regards,
     moreInfoInBylaws: "More information about memberships in the guild bylaws",
     alreadyHaveMembershipForPeriod: "You already have a membership for this period",
     noAvailableMemberships:
-      "No memberships available for purchase. You already have a membership for all available periods.",
+      "No memberships are currently available for purchase. You may already have a membership for every available period, or the next period may not be open yet.",
     willAutoApprove: "Will be automatically approved after payment",
     willRequireApproval: "Will require board approval after payment",
     autoApprovalAdminNote:
@@ -348,6 +348,7 @@ Best regards,
     // Status (aligned with bylaws / säännöt)
     status: {
       active: "Valid membership",
+      activePaymentDue: "Active — new membership fee unpaid",
       resigned: "Resigned",
       renewed: "Renewed",
       rejected: "Rejected",

--- a/src/lib/i18n/fi/index.ts
+++ b/src/lib/i18n/fi/index.ts
@@ -338,7 +338,7 @@ Terveisin,
     moreInfoInBylaws: "Lisätietoja jäsenyyksistä killan säännöissä",
     alreadyHaveMembershipForPeriod: "Sinulla on jo jäsenyys tälle ajanjaksolle",
     noAvailableMemberships:
-      "Ei ostettavia jäsenyyksiä. Sinulla on jo jäsenyys kaikille saatavilla oleville ajanjaksoille.",
+      "Jäsenyyksiä ei ole tällä hetkellä ostettavissa. Sinulla voi jo olla jäsenyys kaikille saatavilla oleville kausille, tai seuraavan kauden jäsenyyksiä ei ole vielä avattu.",
     willAutoApprove: "Hyväksytään automaattisesti maksun jälkeen",
     willRequireApproval: "Vaatii hallituksen hyväksynnän maksun jälkeen",
     autoApprovalAdminNote:
@@ -350,6 +350,7 @@ Terveisin,
     // Status (aligned with bylaws / säännöt)
     status: {
       active: "Voimassa oleva jäsenyys",
+      activePaymentDue: "Voimassa — uusi jäsenmaksu maksamatta",
       resigned: "Eronnut",
       renewed: "Uusittu",
       rejected: "Hylätty",

--- a/src/routes/[locale=locale]/(app)/+page.server.ts
+++ b/src/routes/[locale=locale]/(app)/+page.server.ts
@@ -45,11 +45,13 @@ export const load: PageServerLoad = async (event) => {
   const [availableCount] = await db
     .select({ value: count() })
     .from(table.membership)
+    .innerJoin(table.membershipType, eq(table.membership.membershipTypeId, table.membershipType.id))
     .where(
       and(
         gt(table.membership.endTime, new Date()),
         gte(table.membership.startTime, latestEndTime),
         isNotNull(table.membership.stripePriceId),
+        eq(table.membershipType.purchasable, true),
       ),
     );
 


### PR DESCRIPTION
## What changed

- Show a yellow warning state when membership remains active but its displayed period has ended and a newer purchasable membership exists.
- Make renewal the primary action in that state.
- Align the dashboard availability check with purchasable membership types.
- Clarify that an empty purchase page can also mean the next membership period has not opened yet.

## Why

Membership remains legally active after the displayed period ends, so marking it expired would be incorrect. The previous green active state did not clearly prompt the member to purchase the new period.

The admin QR verification intentionally remains green for these members because it answers whether the person currently has active membership, rather than whether their next fee has been paid.

## Validation

- pnpm check
- pnpm lint
- pnpm test:integration — 96 tests passed