### PR TITLE
chore(ci): migrate to pnpm/setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,16 +66,10 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - name: Use Node.js
-        uses: actions/setup-node@v7
+      - name: Set up pnpm and Node.js
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          node-version-file: package.json
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          cache: true
 
       - name: Get installed playwright-core version
         id: playwright-version

--- a/package.json
+++ b/package.json
@@ -103,6 +103,12 @@
     "valibot": "^1.4.2"
   },
   "packageManager": "pnpm@11.10.0",
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0 <25.0.0"
+    }
+  },
   "engines": {
     "node": ">=22.0.0 <25.0.0"
   }


### PR DESCRIPTION
> [!IMPORTANT]
> **Status: blocked by [pnpm/setup#19](https://github.com/pnpm/setup/issues/19).**
>
> `pnpm/setup` downloads the requested Node runtime, but its automatic `pnpm install` currently resolves the GitHub runner's preinstalled Node from `PATH`. This makes CI fail engine validation. Keep this PR as a draft until the upstream PATH issue is fixed.

## What changed

- replace `pnpm/action-setup` and `actions/setup-node` with the standalone `pnpm/setup` action
- let `pnpm/setup` cache the pnpm store and install dependencies automatically
- declare the supported Node runtime in `devEngines.runtime` so CI reads it from `package.json`

## Why

The project uses pnpm 11, for which `pnpm/setup` is the supported successor. It provisions pnpm and Node in one step and removes the redundant setup and install steps.

The Nix development shell remains the source of Node and pnpm locally; omitting `onFail: download` prevents pnpm from managing a second Node runtime there.