### PR TITLE
refactor(auth): replace deprecated Oslo crypto

### DIFF
--- a/e2e/fixtures/isolated-user.ts
+++ b/e2e/fixtures/isolated-user.ts
@@ -2,9 +2,8 @@ import { test as dbTest } from "./db";
 import type { Page, BrowserContext } from "@playwright/test";
 import * as table from "$lib/server/db/schema";
 import { eq } from "drizzle-orm";
-import { generateUserId } from "../../src/lib/server/auth/utils";
-import { sha256 } from "@oslojs/crypto/sha2";
-import { encodeBase64url, encodeHexLowerCase } from "@oslojs/encoding";
+import { generateUserId, hashSessionToken } from "../../src/lib/server/auth/utils";
+import { encodeBase64url } from "@oslojs/encoding";
 
 export type IsolatedUser = {
   id: string;
@@ -85,7 +84,7 @@ export const test = dbTest.extend<IsolatedUserFixtures>({
   isolatedContext: async ({ browser, db, isolatedUser }, use) => {
     // Create a session for the isolated user
     const sessionToken = encodeBase64url(crypto.getRandomValues(new Uint8Array(18)));
-    const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(sessionToken)));
+    const sessionId = hashSessionToken(sessionToken);
     const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24); // 1 day
 
     await db.insert(table.session).values({

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -3,8 +3,8 @@ import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import * as table from "$lib/server/db/schema";
 import { relations } from "$lib/server/db/relations";
-import { sha256 } from "@oslojs/crypto/sha2";
-import { encodeBase64url, encodeHexLowerCase } from "@oslojs/encoding";
+import { hashSessionToken } from "$lib/server/auth/utils";
+import { encodeBase64url } from "@oslojs/encoding";
 import { eq } from "drizzle-orm";
 import { execSync } from "node:child_process";
 import { loadEnvFile } from "./utils";
@@ -73,7 +73,7 @@ async function globalSetup(_config: FullConfig) {
   }
 
   const sessionToken = generateSessionToken();
-  const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(sessionToken)));
+  const sessionId = hashSessionToken(sessionToken);
   const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 
   await db.insert(table.session).values({
@@ -140,7 +140,7 @@ async function globalSetup(_config: FullConfig) {
 
   // Create session for readonly admin
   const readonlySessionToken = generateSessionToken();
-  const readonlySessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(readonlySessionToken)));
+  const readonlySessionId = hashSessionToken(readonlySessionToken);
   const readonlyExpiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 
   await db.insert(table.session).values({

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
               inherit (finalAttrs) pname version src;
               inherit pnpm;
               fetcherVersion = 4;
-              hash = "sha256-85ew5ZEqDNdKiloqjdECb7MUnof7dzco1CXPwYJ7xkg=";
+              hash = "sha256-Nyrbr1r7lHH97i7EKsqp/kxxVHptKKlyWHUwcoWTL1o=";
             };
 
             installPhase = ''

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",
     "@fontsource-variable/roboto-mono": "^5.3.0",
-    "@oslojs/crypto": "^1.0.1",
     "@oslojs/encoding": "^1.1.0",
     "@simplewebauthn/browser": "^13.3.0",
     "@simplewebauthn/server": "^13.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@fontsource-variable/roboto-mono':
         specifier: ^5.3.0
         version: 5.3.0
-      '@oslojs/crypto':
-        specifier: ^1.0.1
-        version: 1.0.1
       '@oslojs/encoding':
         specifier: ^1.1.0
         version: 1.1.0
@@ -824,18 +821,6 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
-
-  '@oslojs/asn1@1.0.0':
-    resolution: {integrity: sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  '@oslojs/binary@1.0.0':
-    resolution: {integrity: sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  '@oslojs/crypto@1.0.1':
-    resolution: {integrity: sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -4726,17 +4711,6 @@ snapshots:
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
-
-  '@oslojs/asn1@1.0.0':
-    dependencies:
-      '@oslojs/binary': 1.0.0
-
-  '@oslojs/binary@1.0.0': {}
-
-  '@oslojs/crypto@1.0.1':
-    dependencies:
-      '@oslojs/asn1': 1.0.0
-      '@oslojs/binary': 1.0.0
 
   '@oslojs/encoding@1.1.0': {}
 

--- a/src/lib/server/auth/session.ts
+++ b/src/lib/server/auth/session.ts
@@ -1,11 +1,11 @@
 import type { RequestEvent } from "@sveltejs/kit";
 import { eq } from "drizzle-orm";
-import { sha256 } from "@oslojs/crypto/sha2";
-import { encodeBase64url, encodeHexLowerCase } from "@oslojs/encoding";
+import { encodeBase64url } from "@oslojs/encoding";
 import { dev } from "$app/environment";
 import { env } from "$lib/server/env";
 import { db } from "$lib/server/db";
 import * as table from "$lib/server/db/schema";
+import { hashSessionToken } from "./utils";
 const DAY_IN_MS = 1000 * 60 * 60 * 24;
 
 export const sessionCookieName = "auth-session";
@@ -17,7 +17,7 @@ export function generateSessionToken() {
 }
 
 export async function createSession(token: string, userId: string) {
-  const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
+  const sessionId = hashSessionToken(token);
   const session: table.Session = {
     id: sessionId,
     userId,
@@ -28,7 +28,7 @@ export async function createSession(token: string, userId: string) {
 }
 
 export async function validateSessionToken(token: string) {
-  const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
+  const sessionId = hashSessionToken(token);
   const [result] = await db
     .select({
       // Adjust user table here to tweak returned data

--- a/src/lib/server/auth/utils.ts
+++ b/src/lib/server/auth/utils.ts
@@ -1,4 +1,9 @@
 import { encodeBase32LowerCase, encodeBase32UpperCaseNoPadding } from "@oslojs/encoding";
+import { createHash } from "node:crypto";
+
+export function hashSessionToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
 
 export function generateRandomOTP(): string {
   const bytes = new Uint8Array(5);

--- a/tests/gdpr-last-active.test.ts
+++ b/tests/gdpr-last-active.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { eq } from "drizzle-orm";
 import { createTestDatabase, stopTestDatabase, type TestDatabase } from "./utils/db";
 import * as table from "$lib/server/db/schema";
-import { sha256 } from "@oslojs/crypto/sha2";
-import { encodeBase64url, encodeHexLowerCase } from "@oslojs/encoding";
+import { hashSessionToken } from "$lib/server/auth/utils";
+import { encodeBase64url } from "@oslojs/encoding";
 
 function generateSessionToken() {
   const bytes = crypto.getRandomValues(new Uint8Array(18));
@@ -45,7 +45,7 @@ describe("GDPR - lastActiveAt trigger", () => {
 
     // Create a session - this should trigger the lastActiveAt update
     const sessionToken = generateSessionToken();
-    const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(sessionToken)));
+    const sessionId = hashSessionToken(sessionToken);
     const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 
     await db.insert(table.session).values({
@@ -83,7 +83,7 @@ describe("GDPR - lastActiveAt trigger", () => {
 
     // Create a session (this will update lastActiveAt)
     const sessionToken = generateSessionToken();
-    const sessionId = encodeHexLowerCase(sha256(new TextEncoder().encode(sessionToken)));
+    const sessionId = hashSessionToken(sessionToken);
     const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
 
     await db.insert(table.session).values({


### PR DESCRIPTION
## What changed

- replace `@oslojs/crypto` SHA-256 calls with a shared `node:crypto` session-token hashing helper
- use the helper consistently in application, E2E, fixture, and integration-test session creation
- remove `@oslojs/crypto` and its transitive lockfile entries
- retain `@oslojs/encoding`, which remains maintained

## Why

Most Oslo packages have been deprecated. This application only used `@oslojs/crypto` for synchronous SHA-256 hashing, which Node provides natively. Removing the dependency avoids relying on an unmaintained package without changing stored session ID format or authentication behavior.

## Impact

No user-facing behavior changes are expected. Existing and newly created session IDs remain lowercase hexadecimal SHA-256 hashes.

## Backward-compatibility verification

The claim above was verified empirically rather than by inspection. `@oslojs/crypto@1.0.1` is still resolvable in the pnpm store, so both implementations were run side by side:

| Test | Result |
| --- | --- |
| SHA-256 known-answer vector (`"abc"`) | both conformant |
| 200,000 real-shaped session tokens (base64url of 18 random bytes) | 0 mismatches |
| 28 edge cases — lone surrogates, BOM, NUL, noncharacters, NFC/NFD, block-padding boundaries (55/56/63/64/65/119/120 bytes) | 0 mismatches |
| 50,000 random full-BMP strings including unpaired surrogates | 0 mismatches |
| Output format | 64-char lowercase hex, both |

Two conformant implementations of a fixed spec can only diverge at input byte encoding and output hex casing. Both use UTF-8 (`TextEncoder` vs. Node's default `update()` encoding) and lowercase hex, so that is the full surface. Real tokens are ASCII-only regardless — `generateSessionToken()` is base64url over `[A-Za-z0-9_-]`, where UTF-8 is unambiguous.

`session.id` is an unconstrained `text()` primary key, so identical 64-character output stores identically. Existing sessions keep validating, so there is no forced logout on deploy.

`hashSessionToken` is now the only `createHash`/`sha256` call site in the repository, so there is no path to a split session ID namespace.

### One latent behavior difference

| input | old | new |
| --- | --- | --- |
| `undefined` | `e3b0c442…` (`TextEncoder` defaults to `""`) | `TypeError` |
| `null` | `74234e98…` (encodes the string `"null"`) | `TypeError` |

This is unreachable in practice: `hooks.server.ts:20` guards with `if (!sessionToken)` before calling `validateSessionToken`, and the only other caller passes a freshly generated string. Noted for the record — the throwing behavior is the safer failure mode.
