### PR TITLE
Reject overlapping membership imports

### DIFF
--- a/e2e/csv-import.test.ts
+++ b/e2e/csv-import.test.ts
@@ -5,7 +5,7 @@ import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import * as table from "$lib/server/db/schema";
 import { relations } from "$lib/server/db/relations";
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { createVerifiedSecondaryEmail, createUnverifiedSecondaryEmail } from "./helpers/secondary-email";
 import { route } from "../src/lib/ROUTES";
@@ -17,6 +17,7 @@ test.describe("CSV Import", () => {
 
   // Track test data for cleanup
   let testUserIds: string[] = [];
+  let boundaryMembershipIds: string[] = [];
   let tempFiles: string[] = [];
 
   const getTestEmail = (prefix: string) => `${prefix}-${crypto.randomUUID()}@example.com`;
@@ -41,6 +42,11 @@ test.describe("CSV Import", () => {
       await db.delete(table.user).where(eq(table.user.id, userId));
     }
     testUserIds = []; // Reset for next test
+
+    for (const membershipId of boundaryMembershipIds) {
+      await db.delete(table.membership).where(eq(table.membership.id, membershipId));
+    }
+    boundaryMembershipIds = [];
 
     // Clean up temporary CSV files
     for (const tempFile of tempFiles) {
@@ -154,6 +160,140 @@ Test,User,Helsinki,test@example.com,nonexistent-type,2025-08-01`;
     // Verify membership type IDs are listed in the instructions
     await expect(adminPage.getByText("varsinainen-jasen")).toBeVisible();
     await expect(adminPage.getByText("ulkojasen")).toBeVisible();
+  });
+
+  test("rejects overlapping membership types for the same person in one import", async ({ adminPage }) => {
+    const email = getTestEmail("overlapping-types");
+    const tempPath = path.join(process.cwd(), `temp-overlapping-types-${crypto.randomUUID()}.csv`);
+    tempFiles.push(tempPath);
+    fs.writeFileSync(
+      tempPath,
+      `firstNames,lastName,homeMunicipality,email,membershipTypeId,membershipStartDate
+Test,User,Helsinki,${email},varsinainen-jasen,2025-08-01
+Test,User,Helsinki,${email},ulkojasen,2025-08-01`,
+    );
+
+    await adminPage.goto(route("/[locale=locale]/admin/members/import", { locale: "fi" }), {
+      waitUntil: "networkidle",
+    });
+    await adminPage.locator('input[type="file"]').setInputFiles(tempPath);
+    await expect(adminPage.getByText("Tuonnin esikatselu")).toBeVisible({ timeout: 10_000 });
+
+    await adminPage.getByRole("button", { name: /tuo.*jäsen|import.*member/i }).click();
+
+    await expect(adminPage.getByText("Tuotiin 0 / 2 jäsentä")).toBeVisible({ timeout: 10_000 });
+    await adminPage.getByText("Näytä 2 virhettä").click();
+    await expect(adminPage.getByText(/Conflicting approved membership types/).first()).toBeVisible();
+
+    const importedUsers = await db.select().from(table.user).where(eq(table.user.email, email));
+    expect(importedUsers).toHaveLength(0);
+  });
+
+  test("allows different membership types in periods that share an exact boundary", async ({ adminPage }) => {
+    const email = getTestEmail("touching-types");
+    const regularMembershipId = crypto.randomUUID();
+    const externalMembershipId = crypto.randomUUID();
+    boundaryMembershipIds.push(regularMembershipId, externalMembershipId);
+
+    await db.insert(table.membership).values([
+      {
+        id: regularMembershipId,
+        membershipTypeId: "varsinainen-jasen",
+        startTime: new Date("2012-01-01"),
+        endTime: new Date("2013-01-01"),
+        requiresStudentVerification: true,
+      },
+      {
+        id: externalMembershipId,
+        membershipTypeId: "ulkojasen",
+        startTime: new Date("2013-01-01"),
+        endTime: new Date("2014-01-01"),
+        requiresStudentVerification: false,
+      },
+    ]);
+
+    const tempPath = path.join(process.cwd(), `temp-touching-types-${crypto.randomUUID()}.csv`);
+    tempFiles.push(tempPath);
+    fs.writeFileSync(
+      tempPath,
+      `firstNames,lastName,homeMunicipality,email,membershipTypeId,membershipStartDate
+Test,User,Helsinki,${email},varsinainen-jasen,2012-01-01
+Test,User,Helsinki,${email},ulkojasen,2013-01-01`,
+    );
+
+    await adminPage.goto(route("/[locale=locale]/admin/members/import", { locale: "fi" }), {
+      waitUntil: "networkidle",
+    });
+    await adminPage.locator('input[type="file"]').setInputFiles(tempPath);
+    await expect(adminPage.getByText("Tuonnin esikatselu")).toBeVisible({ timeout: 10_000 });
+
+    await adminPage.getByRole("button", { name: /tuo.*jäsen|import.*member/i }).click();
+
+    await expect(adminPage.getByText("Tuotiin 2 / 2 jäsentä")).toBeVisible({ timeout: 10_000 });
+    const [importedUser] = await db.select().from(table.user).where(eq(table.user.email, email));
+    expect(importedUser).toBeDefined();
+    if (!importedUser) throw new Error("Imported user not found");
+    testUserIds.push(importedUser.id);
+
+    const importedMemberships = await db.select().from(table.member).where(eq(table.member.userId, importedUser.id));
+    expect(importedMemberships).toHaveLength(2);
+  });
+
+  test("rejects an imported membership type that overlaps an existing approved type", async ({ adminPage }) => {
+    const email = getTestEmail("existing-overlapping-type");
+    const testUserId = crypto.randomUUID();
+    testUserIds.push(testUserId);
+
+    const [existingMembership] = await db
+      .select({ id: table.membership.id })
+      .from(table.membership)
+      .where(
+        and(
+          eq(table.membership.membershipTypeId, "varsinainen-jasen"),
+          eq(table.membership.startTime, new Date("2025-08-01")),
+        ),
+      );
+    expect(existingMembership).toBeDefined();
+    if (!existingMembership) throw new Error("Seeded 2025 membership not found");
+
+    await db.insert(table.user).values({
+      id: testUserId,
+      email,
+      firstNames: "Existing",
+      lastName: "Member",
+      homeMunicipality: "Espoo",
+      adminRole: "none",
+      isAllowedEmails: false,
+    });
+    await db.insert(table.member).values({
+      id: crypto.randomUUID(),
+      userId: testUserId,
+      membershipId: existingMembership.id,
+      status: "resigned",
+    });
+
+    const tempPath = path.join(process.cwd(), `temp-existing-overlap-${crypto.randomUUID()}.csv`);
+    tempFiles.push(tempPath);
+    fs.writeFileSync(
+      tempPath,
+      `firstNames,lastName,homeMunicipality,email,membershipTypeId,membershipStartDate
+Changed,Name,Helsinki,${email},ulkojasen,2025-08-01`,
+    );
+
+    await adminPage.goto(route("/[locale=locale]/admin/members/import", { locale: "fi" }), {
+      waitUntil: "networkidle",
+    });
+    await adminPage.locator('input[type="file"]').setInputFiles(tempPath);
+    await expect(adminPage.getByText("Tuonnin esikatselu")).toBeVisible({ timeout: 10_000 });
+
+    await adminPage.getByRole("button", { name: /tuo.*jäsen|import.*member/i }).click();
+
+    await expect(adminPage.getByText("Tuotiin 0 / 1 jäsen")).toBeVisible({ timeout: 10_000 });
+    const members = await db.select().from(table.member).where(eq(table.member.userId, testUserId));
+    expect(members).toHaveLength(1);
+
+    const [unchangedUser] = await db.select().from(table.user).where(eq(table.user.id, testUserId));
+    expect(unchangedUser?.firstNames).toBe("Existing");
   });
 
   test("should attach membership to existing user when CSV email is a verified secondary email", async ({

--- a/src/routes/[locale=locale]/(app)/admin/members/import/data.remote.ts
+++ b/src/routes/[locale=locale]/(app)/admin/members/import/data.remote.ts
@@ -3,7 +3,7 @@ import { form, command, getRequestEvent } from "$app/server";
 import * as v from "valibot";
 import { db } from "$lib/server/db";
 import * as table from "$lib/server/db/schema";
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { generateUserId } from "$lib/server/auth/utils";
 import { getUsersByEmails } from "$lib/server/auth/secondary-email";
 import {
@@ -34,6 +34,7 @@ type ProcessedImportRow = {
   row: CsvRow;
   userId: string;
   membershipId: string;
+  membership: ImportMembership;
   status: "active" | "resigned";
   isNewUser: boolean;
 };
@@ -182,9 +183,105 @@ function prepareImportRow(
     row: rowReference.row,
     userId,
     membershipId: membership.id,
+    membership,
     status: membership.endTime < now ? "resigned" : "active",
     isNewUser,
   };
+}
+
+function membershipPeriod(membership: ImportMembership): string {
+  return `${membership.startTime.toISOString().slice(0, 10)}–${membership.endTime.toISOString().slice(0, 10)}`;
+}
+
+function membershipsConflict(left: ImportMembership, right: ImportMembership): boolean {
+  return (
+    left.membershipTypeId !== right.membershipTypeId && left.startTime < right.endTime && right.startTime < left.endTime
+  );
+}
+
+async function loadExistingApprovedMemberships(
+  processedRows: ProcessedImportRow[],
+): Promise<Map<string, ImportMembership[]>> {
+  const userIds = [...new Set(processedRows.map((row) => row.userId))];
+  const membershipsByUserId = new Map<string, ImportMembership[]>();
+
+  for (let i = 0; i < userIds.length; i += IMPORT_BATCH_SIZE) {
+    const userIdBatch = userIds.slice(i, i + IMPORT_BATCH_SIZE);
+    if (userIdBatch.length === 0) continue;
+
+    const existingRows = await db
+      .select({
+        userId: table.member.userId,
+        id: table.membership.id,
+        membershipTypeId: table.membership.membershipTypeId,
+        startTime: table.membership.startTime,
+        endTime: table.membership.endTime,
+      })
+      .from(table.member)
+      .innerJoin(table.membership, eq(table.member.membershipId, table.membership.id))
+      .where(and(inArray(table.member.userId, userIdBatch), inArray(table.member.status, ["active", "resigned"])));
+
+    for (const existingRow of existingRows) {
+      if (!existingRow.userId) continue;
+      const memberships = membershipsByUserId.get(existingRow.userId) ?? [];
+      memberships.push(existingRow);
+      membershipsByUserId.set(existingRow.userId, memberships);
+    }
+  }
+
+  return membershipsByUserId;
+}
+
+async function rejectAmbiguousMembershipTypes(
+  processedRows: ProcessedImportRow[],
+): Promise<{ importableRows: ProcessedImportRow[]; errors: ImportError[] }> {
+  const rowsByUserId = Map.groupBy(processedRows, (row) => row.userId);
+  const existingByUserId = await loadExistingApprovedMemberships(processedRows);
+  const conflictsByUserId = new Map<string, Set<string>>();
+
+  for (const [userId, userRows] of rowsByUserId) {
+    const conflicts = new Set<string>();
+
+    for (let leftIndex = 0; leftIndex < userRows.length; leftIndex++) {
+      const left = userRows[leftIndex];
+      if (!left) continue;
+
+      for (let rightIndex = leftIndex + 1; rightIndex < userRows.length; rightIndex++) {
+        const right = userRows[rightIndex];
+        if (!right || !membershipsConflict(left.membership, right.membership)) continue;
+        conflicts.add(
+          `${left.membership.membershipTypeId} ${membershipPeriod(left.membership)} overlaps ` +
+            `${right.membership.membershipTypeId} ${membershipPeriod(right.membership)} in the import`,
+        );
+      }
+
+      for (const existing of existingByUserId.get(userId) ?? []) {
+        if (!membershipsConflict(left.membership, existing)) continue;
+        conflicts.add(
+          `${left.membership.membershipTypeId} ${membershipPeriod(left.membership)} overlaps existing ` +
+            `${existing.membershipTypeId} ${membershipPeriod(existing)}`,
+        );
+      }
+    }
+
+    if (conflicts.size > 0) conflictsByUserId.set(userId, conflicts);
+  }
+
+  const errors: ImportError[] = [];
+  const importableRows = processedRows.filter((row) => {
+    const conflicts = conflictsByUserId.get(row.userId);
+    if (!conflicts) return true;
+    errors.push(
+      buildImportError(
+        row.row,
+        row.index,
+        `Conflicting approved membership types: ${[...conflicts].join("; ")}. Resolve the membership type before importing.`,
+      ),
+    );
+    return false;
+  });
+
+  return { importableRows, errors };
 }
 
 function prepareImportRows(
@@ -377,12 +474,15 @@ export const importMembers = form(importMembersSchema, async ({ rows: rowsJson }
   const userIdsByEmail = await loadUserIdsByEmail(parsedRows);
   const rows = normalizeImportEmails(parsedRows);
   const { processedRows, errors } = prepareImportRows(rows, membershipLookup, userIdsByEmail);
+  const ambiguityResult = await rejectAmbiguousMembershipTypes(processedRows);
+  errors.push(...ambiguityResult.errors);
+  const importableRows = ambiguityResult.importableRows;
 
-  const uniqueNewUsers = await insertNewUsers(processedRows);
-  await updateExistingUsers(processedRows, errors);
+  const uniqueNewUsers = await insertNewUsers(importableRows);
+  await updateExistingUsers(importableRows, errors);
 
-  const existingMemberKeys = await loadExistingMemberKeys(processedRows);
-  const membersToInsert = getNewMemberRows(processedRows, existingMemberKeys);
+  const existingMemberKeys = await loadExistingMemberKeys(importableRows);
+  const membersToInsert = getNewMemberRows(importableRows, existingMemberKeys);
   await insertNewMembers(membersToInsert, errors);
 
   const errorRowIndices = new Set(errors.map((e) => e.row - 1));


### PR DESCRIPTION
## Summary

- reject an identity from a CSV import when different membership types overlap
- also compare incoming rows with existing active and resigned memberships
- leave sequential periods and rejected applications unaffected
- avoid creating or updating a user when their imported membership history is ambiguous

## Why

The production migration rehearsal found a historical applicant imported as both an external and regular member for the same fee period. The legacy importer only deduplicated exact user and membership pairs, so different membership types for one period were both accepted and historical rows were flattened to resigned.

Rejecting this input forces an administrator to resolve the authoritative membership type instead of silently recording contradictory approved history.

## Validation

- focused ESLint and formatting checks pass
- focused Playwright coverage passes for conflicts within one CSV and against an existing approved row
- full svelte-check currently reaches unrelated missing English translations already present on main